### PR TITLE
Valgrind fixes

### DIFF
--- a/lib/crypto/crypto.h
+++ b/lib/crypto/crypto.h
@@ -95,6 +95,12 @@ typedef struct crypto_session_internal CRYPTO_SESSION;
 int crypto_keys_init(void);
 
 /**
+ * crypto_keys_free(void):
+ * Free the key cache.
+ */
+void crypto_keys_free(void);
+
+/**
  * crypto_keys_import(buf, buflen, keys):
  * Import keys from the provided buffer into the key cache.  Ignore any keys
  * not specified in the mask ${keys}.

--- a/lib/crypto/crypto_file.c
+++ b/lib/crypto/crypto_file.c
@@ -51,6 +51,22 @@ err0:
 	return (-1);
 }
 
+/**
+ * crypto_file_free_keys(void):
+ * Free the keys cached by crypto_file.
+ */
+void crypto_file_free_keys(void)
+{
+
+	/* Clean up decryption cache. */
+	rwhashtab_free(decr_aes_cache);
+
+	/* Clean up encryption key. */
+	if (encr_aes != NULL)
+		crypto_aes_key_free(encr_aes->key);
+	free(encr_aes);
+}
+
 /* Generate encr_aes. */
 static int
 keygen(void)

--- a/lib/crypto/crypto_internal.h
+++ b/lib/crypto/crypto_internal.h
@@ -83,10 +83,22 @@ int crypto_keys_subr_generate_RSA(RSA **, RSA **);
 int crypto_keys_subr_generate_HMAC(struct crypto_hmac_key **);
 
 /**
+ * crypto_keys_subr_free_HMAC(key):
+ * Free an HMAC key.
+ */
+void crypto_keys_subr_free_HMAC(struct crypto_hmac_key **);
+
+/**
  * crypto_file_init_keys(void):
  * Initialize the keys cached by crypto_file.
  */
 int crypto_file_init_keys(void);
+
+/**
+ * crypto_file_free_keys(void):
+ * Free the keys cached by crypto_file.
+ */
+void crypto_file_free_keys(void);
 
 /**
  * crypto_MGF1(seed, seedlen, buf, buflen):

--- a/lib/crypto/crypto_keys_subr.c
+++ b/lib/crypto/crypto_keys_subr.c
@@ -469,3 +469,16 @@ err0:
 	/* Failure! */
 	return (-1);
 }
+
+/**
+ * crypto_keys_subr_free_HMAC(key):
+ * Free an HMAC key.
+ */
+void crypto_keys_subr_free_HMAC(struct crypto_hmac_key ** key)
+{
+
+	if (*key != NULL) {
+		free((*key)->key);
+		free(*key);
+	}
+}

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -230,6 +230,7 @@ enum {
 };
 
 
+void	bsdtar_free_allocated(struct bsdtar *);
 void	bsdtar_errc(struct bsdtar *, int _eval, int _code,
 	    const char *fmt, ...) __LA_DEAD;
 int	bsdtar_getopt(struct bsdtar *);

--- a/tar/chunks/chunks_directory.c
+++ b/tar/chunks/chunks_directory.c
@@ -341,6 +341,9 @@ chunks_directory_write(const char * cachepath, RWHASHTAB * HT,
 		goto err1;
 	}
 
+	/* Free string allocated by asprintf. */
+	free(s);
+
 	/* Success! */
 	return (0);
 

--- a/tar/multitape/multitape_write.c
+++ b/tar/multitape/multitape_write.c
@@ -898,6 +898,10 @@ writetape_close(TAPE_W * d)
 	chunkify_free(d->t.c);
 	chunkify_free(d->c.c);
 	chunkify_free(d->h.c);
+	free(d->t.index);
+	free(d->c.index);
+	free(d->h.index);
+	free(d->hbuf);
 	free(d->cachedir);
 	free(d->tapename);
 	free(d);
@@ -914,6 +918,10 @@ err1:
 	chunkify_free(d->t.c);
 	chunkify_free(d->c.c);
 	chunkify_free(d->h.c);
+	free(d->t.index);
+	free(d->c.index);
+	free(d->h.index);
+	free(d->hbuf);
 	free(d->cachedir);
 	free(d->tapename);
 	free(d);
@@ -937,6 +945,16 @@ writetape_free(TAPE_W * d)
 	chunkify_free(d->t.c);
 	chunkify_free(d->c.c);
 	chunkify_free(d->h.c);
+	/*
+	 * The .index and hbuf are not allocated yet (since
+	 * writetape_free is only called from
+	 * archive_write_open_multitape()), but I imitate the
+	 * cleanup of writetable_close().
+	 */
+	free(d->t.index);
+	free(d->c.index);
+	free(d->h.index);
+	free(d->hbuf);
 	free(d->cachedir);
 	free(d->tapename);
 	free(d);

--- a/tar/util.c
+++ b/tar/util.c
@@ -228,6 +228,23 @@ bsdtar_warnc(struct bsdtar *bsdtar, int code, const char *fmt, ...)
 	va_end(ap);
 }
 
+/*
+ * Free any allocated memory within the bsdtar structure.
+ */
+void
+bsdtar_free_allocated(struct bsdtar *bsdtar)
+{
+
+	/* These come from malloc(). */
+	free(bsdtar->tapenames);
+	free(bsdtar->configfiles);
+
+	/* These come from strdup(). */
+	free(bsdtar->cachedir);
+	/* free() doesn't accept const, so we cast it away. */
+	free((char*)bsdtar->homedir);
+}
+
 void
 bsdtar_errc(struct bsdtar *bsdtar, int eval, int code, const char *fmt, ...)
 {
@@ -236,6 +253,7 @@ bsdtar_errc(struct bsdtar *bsdtar, int eval, int code, const char *fmt, ...)
 	va_start(ap, fmt);
 	bsdtar_vwarnc(bsdtar, code, fmt, ap);
 	va_end(ap);
+	bsdtar_free_allocated(bsdtar);
 	exit(eval);
 }
 


### PR DESCRIPTION
First draft of the first round of valgrind fixes.  These allow us to run, without valgrind-detected memory leaks,

    tarsnap
    tarsnap --help
    tarsnap --version
    tarsnap -c --dry-run ~/whatever/