### PR TITLE
Bash completion packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,17 @@ but for experimental development, use:
     ./configure
     make
 
+
+Packaging notes
+---------------
+
+Bash completion scripts: optional `configure` argument
+`--with-bash-completion-dir[=DIR]`.
+
+* If `DIR` is specified, it installs to that directory.
+
+* If `DIR` is left blank, it attempts to use `pkg-config` and
+  `bash-completion >= 2.0` to determine where to put the bash
+  completion scripts.  If your system does not match those
+  requirements, please specify `DIR` explicitly.
+

--- a/configure.ac
+++ b/configure.ac
@@ -460,15 +460,15 @@ AS_IF([test "x$with_bash_completion_dir" != "xno"],
 
 # should we set the value automatically?
 if test "x$with_bash_completion_dir" == "xyes"; then
-    # default guess for automatic
-    BASH_COMPLETION_DIR="$datadir/bash-completion/completions"
-
     # try to use pkg-config
     AC_CHECK_PROG(HAS_PKG_CONFIG, pkg-config, yes)
-    if test "x$HAS_PKG_CONFIG" != "xno"; then
+    if test "x$HAS_PKG_CONFIG" != "xyes"; then
+        AC_MSG_ERROR([Automatic detection of bash-completion directory requires pkg-config.])
+    else
         # find the actual value from the system
         PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
-            [BASH_COMPLETION_DIR="`pkg-config --variable=completionsdir bash-completion`"])
+            [BASH_COMPLETION_DIR="`pkg-config --variable=completionsdir bash-completion`"],
+            [AC_MSG_ERROR([Automatic detection of bash-completion directory requires bash-completion >= 2.0.])])
 	AC_MSG_CHECKING([bash completions directory])
 	AC_MSG_RESULT([$BASH_COMPLETION_DIR])
     fi

--- a/misc/bash_completion.d/tarsnap
+++ b/misc/bash_completion.d/tarsnap
@@ -58,7 +58,7 @@ _tarsnap ()
 		  --no-maxbw --no-maxbw-rate-down --no-maxbw-rate-up --no-nodump --no-print-stats \
 		  --no-snaptime --no-store-atime --no-totals --store-atime --totals --recover \
 		  --insane-filesystems --quiet --no-quiet --configfile --no-default-config --fsck-prune \
-		  --retry-forever --no-retry-forever"
+		  --retry-forever --no-retry-forever --creationtime"
 
 	# Availible short options
 	shortopts="-c -d -t -x -r -C -f -H -h -I -k -L -l -m -n -O -o -P -p -q -S -s -T -U -v -w -X -q"

--- a/misc/bash_completion.d/tarsnap
+++ b/misc/bash_completion.d/tarsnap
@@ -1,11 +1,5 @@
 # bash-completion for tarsnap
 #
-# Besides supplying options it will also try to determine
-# when it is suitible to complete what.
-#
-# Feel free to send comments or suggestions.
-#
-#
 # Copyright (c) 2009-2012 Andreas Olsson
 # 
 # Permission is hereby granted, free of charge, to any person

--- a/misc/bash_completion.d/tarsnap-keygen
+++ b/misc/bash_completion.d/tarsnap-keygen
@@ -1,11 +1,5 @@
 # bash-completion for tarsnap-keygen
 #
-# Besides supplying options it will also try to determine
-# when it is suitible to complete what.
-#
-# Feel free to send comments or suggestions.
-#
-#
 # Copyright (c) 2009-2012 Andreas Olsson
 # 
 # Permission is hereby granted, free of charge, to any person

--- a/misc/bash_completion.d/tarsnap-keymgmt
+++ b/misc/bash_completion.d/tarsnap-keymgmt
@@ -1,11 +1,5 @@
 # bash-completion for tarsnap-keymgmt
 #
-# Besides supplying options it will also try to determine
-# when it is suitible to complete what.
-#
-# Feel free to send comments or suggestions.
-#
-#
 # Copyright (c) 2009-2012 Andreas Olsson
 # 
 # Permission is hereby granted, free of charge, to any person

--- a/misc/bash_completion.d/tarsnap-keyregen
+++ b/misc/bash_completion.d/tarsnap-keyregen
@@ -1,11 +1,5 @@
 # bash-completion for tarsnap-keyregen
 #
-# Besides supplying options it will also try to determine
-# when it is suitible to complete what.
-#
-# Feel free to send comments or suggestions.
-#
-#
 # Copyright (c) 2009-2012 Andreas Olsson
 # 
 # Permission is hereby granted, free of charge, to any person

--- a/misc/bash_completion.d/tarsnap-recrypt
+++ b/misc/bash_completion.d/tarsnap-recrypt
@@ -1,11 +1,5 @@
 # bash-completion for tarsnap-recrypt
 #
-# Besides supplying options it will also try to determine
-# when it is suitible to complete what.
-#
-# Feel free to send comments or suggestions.
-#
-#
 # Copyright (c) 2009-2012 Andreas Olsson
 # 
 # Permission is hereby granted, free of charge, to any person


### PR DESCRIPTION
First round of updates for bash-completion and Debian packages.

This does *not* enable `--with-bash-completion-dir` in the debian package.  I have not yet been able to test that successfully; I still have a lot to learn about debian packages.