### PR TITLE
FIXME Free more multitape memory

### DIFF
--- a/tar/multitape/multitape_write.c
+++ b/tar/multitape/multitape_write.c
@@ -898,6 +898,10 @@ writetape_close(TAPE_W * d)
 	chunkify_free(d->t.c);
 	chunkify_free(d->c.c);
 	chunkify_free(d->h.c);
+	free(d->t.index);
+	free(d->c.index);
+	free(d->h.index);
+	free(d->hbuf);
 	free(d->cachedir);
 	free(d->tapename);
 	free(d);
@@ -914,6 +918,10 @@ err1:
 	chunkify_free(d->t.c);
 	chunkify_free(d->c.c);
 	chunkify_free(d->h.c);
+	free(d->t.index);
+	free(d->c.index);
+	free(d->h.index);
+	free(d->hbuf);
 	free(d->cachedir);
 	free(d->tapename);
 	free(d);
@@ -937,6 +945,16 @@ writetape_free(TAPE_W * d)
 	chunkify_free(d->t.c);
 	chunkify_free(d->c.c);
 	chunkify_free(d->h.c);
+	/*
+	 * The .index and hbuf are not allocated yet (since
+	 * writetape_free is only called from
+	 * archive_write_open_multitape()), but I imitate the
+	 * cleanup of writetable_close().
+	 */
+	free(d->t.index);
+	free(d->c.index);
+	free(d->h.index);
+	free(d->hbuf);
 	free(d->cachedir);
 	free(d->tapename);
 	free(d);


### PR DESCRIPTION
(this PR needs attention from @cperciva, but it likely needs at least one more draft before being suitable for pushing)

This allows
    tarsnap -c --dry-run ~/whatever/
without any valgrind-reported memory leaks.
(this leak also appears with "tarsnap -c -f name ~/whatever")

In particular, there are 3 leaks, all in
tar/multitape/multitape_write.c

- 2 occur on line 203:
      index_new = realloc(S->index, indexalloc_new);
  (called via different callbacks)
- 1 is on line 559:
      hbuf_new = realloc(d->hbuf, hbufalloc_new);

FIXME: this patch does a few more "free()" than strictly necessary
to resolve this leak.  I figured that there was no harm in
free(NULL), but I could create a "minimal" patch instead.