### PR TITLE
Warn if target of hard-link is not present

### DIFF
--- a/libarchive/archive_write_disk.c
+++ b/libarchive/archive_write_disk.c
@@ -941,6 +941,13 @@ restore_entry(struct archive_write_disk *a)
 		en = create_filesystem_object(a);
 	}
 
+	if ((en == ENOENT) && (archive_entry_hardlink(a->entry) != NULL)) {
+		archive_set_error(&a->archive, en,
+		    "Hard-link target '%s' does not exist.",
+		    archive_entry_hardlink(a->entry));
+		return (ARCHIVE_FAILED);
+	}
+
 	if ((en == EISDIR || en == EEXIST)
 	    && (a->flags & ARCHIVE_EXTRACT_NO_OVERWRITE)) {
 		/* If we're not overwriting, we're done. */


### PR DESCRIPTION
Here's a first draft for discussion.  It produces:

```
td@gin: ~/src/tarsnap/build (warn-hard-links)
$ ./tarsnap -x -f foo b
b: Hard-link target 'a' does not exist.  Can't create 'b'
tarsnap: Error exit delayed from previous errors.
```

The actual error message is printed from the bottom of `restore_entry()`; that's the function immediately above `create_filesystem_object()` in ` libarchive/archive_write_disk.c` so it's easy to see it in github.  In particular, that function calls `create_filesystem_object(a)` multiple times (doing things like trying to create intermediate directories if the initial call fails).  In the case of a hardlink to a non-existent target, it calls  `create_filesystem_object(a)` twice before reaching the `/* Everything failed; give up here. */` on line 1046.

I hesitated about including `archive_clear_error(&a->archive);` in `create_filesystem_object()`, but without that line, it would print the "Hard-link" sentence twice.

NB: the bottom of `restore_entry()` appends "Can't create '%s'` to the error message.  I'm not sold on format of the combined message (especially without a final period!), but I don't know how much of the original libarchive code you want me to be modifying.  The current patch is an attempt at being minimally invasive.

POSIX link http://pubs.opengroup.org/onlinepubs/9699919799/functions/link.html says

[ENOENT]
A component of either path prefix does not exist; the file named by path1 does not exist; or path1 or path2 points to an empty string.

The patch does not check for the "component of either path not existing" case. (restore_entry() tries creating the parent dir of the link, but doesn't check the return value of that function so it could silently fail!)