### PR TITLE
Free dns and string

### DIFF
--- a/lib/netproto/netproto_connect.c
+++ b/lib/netproto/netproto_connect.c
@@ -24,6 +24,16 @@ struct netproto_connect_cookie {
 	NETPROTO_CONNECTION * NC;
 };
 
+static struct sock_addr ** srv_addr = NULL;
+static void netproto_connect_atexit(void);
+
+static void
+netproto_connect_atexit(void)
+{
+
+	sock_addr_freelist(srv_addr);
+}
+
 static int
 callback_connect(void * cookie, int s)
 {
@@ -105,7 +115,6 @@ callback_cancel(void * cookie)
 static struct sock_addr **
 getserveraddr(void)
 {
-	static struct sock_addr ** srv_addr = NULL;
 	static time_t srv_time = (time_t)(-1);
 	struct sock_addr ** tmp_addr;
 	time_t tmp_time;
@@ -129,6 +138,10 @@ getserveraddr(void)
 
 	/* If we have a new lookup, update the cache. */
 	if (tmp_addr != NULL) {
+		if ((srv_addr == NULL) && (atexit(netproto_connect_atexit))) {
+			warnp("Could not initialize atexit");
+			exit(1);
+		}
 		sock_addr_freelist(srv_addr);
 		srv_addr = tmp_addr;
 		srv_time = tmp_time;

--- a/tar/chunks/chunks_directory.c
+++ b/tar/chunks/chunks_directory.c
@@ -341,6 +341,9 @@ chunks_directory_write(const char * cachepath, RWHASHTAB * HT,
 		goto err1;
 	}
 
+	/* Free string allocated by asprintf. */
+	free(s);
+
 	/* Success! */
 	return (0);
 


### PR DESCRIPTION
Split off from https://github.com/Tarsnap/tarsnap/pull/46#discussion_r38257258.

I'm not at all certain what we should do if `getserveraddr` fails to allocate the `atexit`.  I slapped a `warnp(); exit(1);` in there, but I have a feeling you'll have a better idea.