### PR TITLE
Do not refer an uninitialized or empty symlink name.

### DIFF
--- a/libarchive/archive_write_disk.c
+++ b/libarchive/archive_write_disk.c
@@ -1402,7 +1402,7 @@ current_fixup(struct archive_write_disk *a, const char *pathname)
 static int
 check_symlinks(struct archive_write_disk *a)
 {
-	char *pn, *p;
+	char *pn;
 	char c;
 	int r;
 	struct stat st;
@@ -1413,9 +1413,11 @@ check_symlinks(struct archive_write_disk *a)
 	 */
 	/* Whatever we checked last time doesn't need to be re-checked. */
 	pn = a->name;
-	p = a->path_safe.s;
-	while ((*pn != '\0') && (*p == *pn))
-		++p, ++pn;
+	if (archive_strlen(&(a->path_safe)) > 0) {
+		char *p = a->path_safe.s;
+		while ((*pn != '\0') && (*p == *pn))
+			++p, ++pn;
+	}
 	c = pn[0];
 	/* Keep going until we've checked the entire name. */
 	while (pn[0] != '\0' && (pn[0] != '/' || pn[1] != '\0')) {


### PR DESCRIPTION
Imported from libarchive v3.0.2.
https://github.com/libarchive/libarchive/commit/8e0dd6534ecc99ae4c53b58361e0591c64848d87
libarchive-SVN-Revision: 3909

gperciva: I renamed the file from

    libarchive/archive_write_disk_posix.c

to

    libarchive/archive_write_disk.c

but the patch is otherwise identical.