### PR TITLE
Match style of existing key*gen code for maxtime

### DIFF
--- a/keygen/keygen.c
+++ b/keygen/keygen.c
@@ -74,7 +74,7 @@ main(int argc, char **argv)
 	NETPACKET_CONNECTION * NPC;
 	int passphrased;
 	uint64_t maxmem;
-	double maxtime = 1.0;
+	double maxtime;
 	char * passphrase;
 
 	WARNP_INIT;
@@ -83,9 +83,13 @@ main(int argc, char **argv)
 	C.user = C.name = NULL;
 	keyfilename = NULL;
 
-	/* We're not using a passphrase, and have unlimited RAM so far. */
+	/*
+	 * So far we're not using a passphrase, have unlimited RAM, and allow
+	 * up to 1 second of CPU time.
+	 */
 	passphrased = 0;
 	maxmem = 0;
+	maxtime = 1.0;
 
 	/* Parse arguments. */
 	while (--argc > 0) {

--- a/keyregen/keyregen.c
+++ b/keyregen/keyregen.c
@@ -75,7 +75,7 @@ main(int argc, char **argv)
 	NETPACKET_CONNECTION * NPC;
 	int passphrased;
 	uint64_t maxmem;
-	double maxtime = 1.0;
+	double maxtime;
 	char * passphrase;
 	uint64_t dummy;
 
@@ -89,9 +89,13 @@ main(int argc, char **argv)
 	keyfilename = NULL;
 	oldkeyfilename = NULL;
 
-	/* We're not using a passphrase, and have unlimited RAM so far. */
+	/*
+	 * So far we're not using a passphrase, have unlimited RAM, and allow
+	 * up to 1 second of CPU time.
+	 */
 	passphrased = 0;
 	maxmem = 0;
+	maxtime = 1.0;
 
 	/* Parse arguments. */
 	while (--argc > 0) {


### PR DESCRIPTION
Not desperately important, but I figured I'd get this out of the way before doing a PR for keygen refactoring.

Note that `keymgmt` uses a different style for `passphrased` and `maxmem` initialization, so I didn't change that.