### PR TITLE
avoid some memory operations with NULL

### DIFF
--- a/lib/network/tsnetwork_writeq.c
+++ b/lib/network/tsnetwork_writeq.c
@@ -2,6 +2,7 @@
 
 #include <sys/time.h>
 
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -34,6 +35,9 @@ dowrite(struct network_writeq_internal * Q)
 {
 	struct network_writeq_buf * QB = Q->head;
 	struct timeval timeo;
+
+	/* Sanity check that the queue is non-empty */
+	assert(Q->head != NULL);
 
 	/* Figure out how long to allow for this buffer write. */
 	memcpy(&timeo, &QB->timeo, sizeof(struct timeval));

--- a/tar/storage/storage_read.c
+++ b/tar/storage/storage_read.c
@@ -66,6 +66,7 @@ cache_lru_remove(STORAGE_R * S, struct read_file_cached * CF)
 {
 
 	/* Sanity check: We should be in the queue. */
+	assert(CF != NULL);
 	assert(CF->inqueue);
 
 	/* Our LRU file is now someone else's LRU file. */


### PR DESCRIPTION
These arose from the clang static analyzer.