### PR TITLE
Backport libarchive strdup allocation failure check

### DIFF
--- a/libarchive/archive_read_support_compression_program.c
+++ b/libarchive/archive_read_support_compression_program.c
@@ -154,8 +154,10 @@ archive_read_support_compression_program_signature(struct archive *_a,
 	 */
 	state = (struct program_bidder *)calloc(sizeof (*state), 1);
 	if (state == NULL)
-		return (ARCHIVE_FATAL);
+		goto memerr;
 	state->cmd = strdup(cmd);
+	if (state->cmd == NULL)
+		goto memerr;
 	if (signature != NULL && signature_len > 0) {
 		state->signature_len = signature_len;
 		state->signature = malloc(signature_len);
@@ -171,6 +173,11 @@ archive_read_support_compression_program_signature(struct archive *_a,
 	bidder->options = NULL;
 	bidder->free = program_bidder_free;
 	return (ARCHIVE_OK);
+
+memerr:
+	free(state);
+	archive_set_error(_a, ENOMEM, "Can't allocate memory");
+	return (ARCHIVE_FATAL);
 }
 
 static int


### PR DESCRIPTION
This is extracted from a much larger commit:
https://github.com/libarchive/libarchive/commit/40722a255fe8f25a6a8dcd9d66fda49478756b17#diff-0cef2313059c42005d9a2fcaf32023ddR231

(with a few changes for it to make sense with the Tarsnap libarchive code)