### PR TITLE
Check for strdup() allocation failure

### DIFF
--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -1712,7 +1712,10 @@ archive_entry_xattr_add_entry(struct archive_entry *entry,
 		/* XXX Error XXX */
 		return;
 
-	xp->name = strdup(name);
+	if ((xp->name = strdup(name)) == NULL)
+		/* XXX Error XXX */
+		return;
+
 	if ((xp->value = malloc(size)) != NULL) {
 		memcpy(xp->value, value, size);
 		xp->size = size;


### PR DESCRIPTION
This is backported from
https://github.com/libarchive/libarchive/commit/df6ba947752d58a519afcb9f5846b9e9f47c892a
(filename change libarchive/archive_entry_xattr.c to
libarchive/archive_entry.c for Tarsnap's old libarchive version)