### PR TITLE
Compiler warnings

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,8 @@
 
 AUTOMAKE_OPTIONS= foreign subdir-objects
 
+CFLAGS += -Wall -Wextra -Wno-unused-function
+
 #
 # What to build and install
 #

--- a/libarchive/archive_check_magic.c
+++ b/libarchive/archive_check_magic.c
@@ -69,8 +69,7 @@ diediedie(void)
 	/* Cause a breakpoint exception  */
 	DebugBreak();
 #endif
-	*(volatile char *)0 = 1;	/* Deliberately segfault and force a coredump. */
-	_exit(1);	/* If that didn't work, just exit with an error. */
+	abort();        /* Terminate the program abnormally. */
 }
 
 static const char *

--- a/libarchive/archive_check_magic.c
+++ b/libarchive/archive_check_magic.c
@@ -50,7 +50,16 @@ __FBSDID("$FreeBSD: src/lib/libarchive/archive_check_magic.c,v 1.9 2008/12/06 05
 static void
 errmsg(const char *m)
 {
-	write(2, m, strlen(m));
+	size_t s = strlen(m);
+	ssize_t written;
+
+	while (s > 0) {
+		written = write(2, m, strlen(m));
+		if (written <= 0)
+			return;
+		m += written;
+		s -= written;
+	}
 }
 
 static void


### PR DESCRIPTION
This backports 3 commits from libarchive, then enables -Wall -Wextra -Werror.

I know you don't like playing silly games with `(void)unused_var;` just to satisfy silly warnings about ignoring the returned value of `write()`, but we could have avoided https://github.com/Tarsnap/tarsnap/pull/69 if we had `-Werror`.  Also, I would feel better if I knew that my patches didn't cause any warnings, but when we have known warnings in the build, we tend to ignore anything that flashes on the screen (especially since they end up buried by other compile messages).

Any chance of this getting in?  Note that I have not directly modified any tarsnap `.c` code in order to achieve `-Werror` success; the only changes came from upstream libarchive.