### PR TITLE
Apply "handle short writes correctly" to others

### DIFF
--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -41,6 +41,21 @@ __FBSDID("$FreeBSD: src/lib/libarchive/archive_util.c,v 1.19 2008/10/21 12:10:30
 #include "archive_private.h"
 #include "archive_string.h"
 
+static void
+errmsg(const char *m)
+{
+	size_t s = strlen(m);
+	ssize_t written;
+
+	while (s > 0) {
+		written = write(2, m, strlen(m));
+		if (written <= 0)
+			return;
+		m += written;
+		s -= written;
+	}
+}
+
 #if ARCHIVE_VERSION_NUMBER < 3000000
 /* These disappear in libarchive 3.0 */
 /* Deprecated. */
@@ -182,9 +197,9 @@ void
 __archive_errx(int retvalue, const char *msg)
 {
 	static const char *msg1 = "Fatal Internal Error in libarchive: ";
-	write(2, msg1, strlen(msg1));
-	write(2, msg, strlen(msg));
-	write(2, "\n", 1);
+	errmsg(msg1);
+	errmsg(msg);
+	errmsg("\n");
 	exit(retvalue);
 }
 

--- a/libarchive/archive_write_set_format_pax.c
+++ b/libarchive/archive_write_set_format_pax.c
@@ -74,6 +74,21 @@ static int		 has_non_ASCII(const wchar_t *);
 static char		*url_encode(const char *in);
 static int		 write_nulls(struct archive_write *, size_t);
 
+static void
+errmsg(const char *m)
+{
+	size_t s = strlen(m);
+	ssize_t written;
+
+	while (s > 0) {
+		written = write(2, m, strlen(m));
+		if (written <= 0)
+			return;
+		m += written;
+		s -= written;
+	}
+}
+
 /*
  * Set output format to 'restricted pax' format.
  *
@@ -945,7 +960,7 @@ archive_write_pax_header(struct archive_write *a,
 		if (r != 0) {
 			const char *msg = "archive_write_pax_header: "
 			    "'x' header failed?!  This can't happen.\n";
-			write(2, msg, strlen(msg));
+			errmsg(msg);
 			exit(1);
 		}
 		r = (a->compressor.write)(a, paxbuff, 512);

--- a/tar/tree.c
+++ b/tar/tree.c
@@ -154,6 +154,21 @@ struct tree {
 #define D_NAMELEN(dp)	(strlen((dp)->d_name))
 #endif
 
+static void
+errmsg(const char *m)
+{
+	size_t s = strlen(m);
+	ssize_t written;
+
+	while (s > 0) {
+		written = write(2, m, strlen(m));
+		if (written <= 0)
+			return;
+		m += written;
+		s -= written;
+	}
+}
+
 #if 0
 #include <stdio.h>
 void
@@ -358,7 +373,7 @@ tree_next(struct tree *t)
 	if (t->visit_type == TREE_ERROR_FATAL) {
 		const char *msg = "Unable to continue traversing"
 		    " directory hierarchy after a fatal error.\n";
-		write(2, msg, strlen(msg));
+		errmsg(msg);
 		*(volatile int *)0 = 1; /* Deliberate SEGV; NULL pointer dereference. */
 		exit(1); /* In case the SEGV didn't work. */
 	}


### PR DESCRIPTION
If `errmsg()` from 23fbfb0 is good enough for `archive_check_magic.c`, then let's use it in
other files as well.  This also cleans up compile warnings with gcc.

I considered making `errmsg()` a more accessible libarchive function (and only defined once), but it wouldn't be accessible by `tree.c` so I dropped that idea.