### PR TITLE
chunkification: avoid reading uninitialized memory

### DIFF
--- a/tar/multitape/chunkify.c
+++ b/tar/multitape/chunkify.c
@@ -137,8 +137,8 @@ chunkify_start(CHUNKIFIER * c)
 	uint32_t i;
 
 	/* No entries in the hash table. */
-	for (i = 0; i < c->htlen; i++)
-		c->ht[i * 2] = - c->htlen;
+	for (i = 0; i < 2 * c->htlen; i++)
+		c->ht[i] = - c->htlen;
 
 	/* Nothing in the queue waiting to be added to the table, either. */
 	for (i = 0; i < c->w; i++)


### PR DESCRIPTION
Previously, only the even positions in the hash table c->ht were initialized.
As a result, when the input chunk was larger than 16K [1] and we check if we
have found yka (by examining the odd positions), we would be reading
uninitialized memory.  Other than standard compliance, there was no danger in
this: even if the uninitialized memory happened to match yka, the cache entry
would not be recent enough to be considered valid [2].

[1] c->mu = 64k; c->rs = 1+c->mu; c->rs -= 4 for each byte in the input
buffer; if c->rs <= 4 then c->r is non-zero and we reach the "Check if yka is
in the hash table".

[2] c->ht[2*i] is initialized to -c->htlen, so
(c->k - c->ht[2 * htpos] - 1 < c->r) will not be true.