### PR TITLE
Dryrun keyless ignore config

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -112,7 +112,7 @@ static int		 configfile_helper(struct bsdtar *bsdtar,
 			     const char *line);
 static void		 dooption(struct bsdtar *, const char *,
 			     const char *, int);
-static void		 load_keys(struct bsdtar *, const char *path);
+static int		 load_keys(struct bsdtar *, const char *path);
 static void		 long_help(struct bsdtar *);
 static void		 only_mode(struct bsdtar *, const char *opt,
 			     const char *valid);
@@ -867,6 +867,19 @@ main(int argc, char **argv)
 		only_mode(bsdtar, "--strip-components", "xt");
 
 	/*
+	 * If the keyfile in the config file is invalid but we're doing a
+	 * dryrun, continue anyway (and don't use a cachedir).
+	 */
+	if (bsdtar->config_file_keyfile_failed && bsdtar->option_dryrun &&
+	    bsdtar->cachedir != NULL) {
+		bsdtar_warnc(bsdtar, 0,
+		    "Ignoring cachedir due to missing or invalid "
+		    "keyfile in config file.");
+		free(bsdtar->cachedir);
+		bsdtar->cachedir = NULL;
+	}
+
+	/*
 	 * Canonicalize the path to the cache directories.  This is
 	 * necessary since the tar code can change directories.
 	 */
@@ -1453,8 +1466,16 @@ dooption(struct bsdtar *bsdtar, const char * conf_opt,
 		if (conf_arg == NULL)
 			goto needarg;
 
-		load_keys(bsdtar, conf_arg);
-		bsdtar->have_keys = 1;
+		if (load_keys(bsdtar, conf_arg) == 0)
+			bsdtar->have_keys = 1;
+		else {
+			if (fromconffile && bsdtar->option_dryrun)
+				bsdtar->config_file_keyfile_failed = 1;
+			else {
+				bsdtar_errc(bsdtar, 1, errno,
+				    "Cannot read key file: %s", conf_arg);
+			}
+		}
 	} else if (strcmp(conf_opt, "lowmem") == 0) {
 		if (bsdtar->mode != 'c')
 			goto badmode;
@@ -1688,16 +1709,15 @@ badopt:
 	    "Unrecognized configuration file option: \"%s\"", conf_opt);
 }
 
-/* Load keys from the specified file. */
-static void
+/* Load keys from the specified file.  Return success or failure. */
+static int
 load_keys(struct bsdtar *bsdtar, const char *path)
 {
 	uint64_t machinenum;
 
 	/* Load the key file. */
 	if (keyfile_read(path, &machinenum, ~0))
-		bsdtar_errc(bsdtar, 1, errno,
-		    "Cannot read key file: %s", path);
+		goto err0;
 
 	/* Check the machine number. */
 	if ((bsdtar->machinenum != (uint64_t)(-1)) &&
@@ -1705,6 +1725,13 @@ load_keys(struct bsdtar *bsdtar, const char *path)
 		bsdtar_errc(bsdtar, 1, 0,
 		    "Key file belongs to wrong machine: %s", path);
 	bsdtar->machinenum = machinenum;
+
+	/* Success! */
+	return (0);
+
+err0:
+	/* Failure! */
+	return (-1);
 }
 
 static int

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -127,6 +127,9 @@ struct bsdtar {
 	char		  warned_lead_slash; /* Already displayed warning */
 	char		  next_line_is_dir; /* Used for -C parsing in -cT */
 
+	/* Used for --dryrun with tarsnap.conf.sample with a missing keyfile. */
+	int		  config_file_keyfile_failed;
+
 	/* Used for communicating with multitape code. */
 	void		 *write_cookie;
 


### PR DESCRIPTION
Addresses #89 

I went back and forth half a dozen times between handling `fromconffile` in `load_keys()` vs. `dooption()`.  In the end, I went with `load_keys()` since `dooption()` is already pretty long, and each option isn't very long.  But I wimped out on doing *everything* in `load_keys()`; I left `bsdtar->have_keys = 1` in `dooption()` since that's where it was originally.  I think it might be better to move that into `load_keys()`; if we did that, `load_keys()` could go back to being `void` instead of the `int` that I changed it to.

Basically: adding the functionality was trivial.  Trying to make it match the desired style was not.  :|