### PR TITLE
Build: if bash completion <= 2.0, set a default dir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -468,7 +468,8 @@ if test "x$with_bash_completion_dir" = "xyes"; then
         # find the actual value from the system
         PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
             [BASH_COMPLETION_DIR="`pkg-config --variable=completionsdir bash-completion`"],
-            [AC_MSG_ERROR([Automatic detection of bash-completion directory requires bash-completion >= 2.0.])])
+            [BASH_COMPLETION_DIR="/etc/bash_completion.d/"; 
+	     AC_MSG_WARN([Automatic detection of bash-completion directory requires bash-completion >= 2.0; guessing a directory.])])
 	AC_MSG_CHECKING([bash completions directory])
 	AC_MSG_RESULT([$BASH_COMPLETION_DIR])
     fi


### PR DESCRIPTION
Previously if the system did not have bash-completion and the user asked for
an automatic directory, the configure script would quit.  Now, it attempts to
continue by setting the directory to the value suitable for Ubuntu 12.04
(since I estimate this is a combination of "most popular" and "most likely to
have users who aren't comfortable specifying a directory in
--with-bash-completion-dir[=DIR]").

Note that FreeBSD ports upgraded to bash-completion 2.0 on 02 Nov 2012
(revision 306891), and debian wheezy 7.0 on 04 May 2013 uses bash-completion
2.0.  So it's only old servers that don't have 2.0.

The main reason I'm making this change is so that the deb packages can rely on
autodetection (and fallback on Ubuntu 12.04), instead of needing to hard-code
an old directory on modern distributions.