### PR TITLE
Bsdtar better cleanup

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -196,6 +196,9 @@ bsdtar_atexit(void)
 #if HAVE_REGEX_H
 	cleanup_substitution(bsdtar);
 #endif
+
+	/* Clean up network layer. */
+	network_fini();
 }
 
 int
@@ -1023,9 +1026,6 @@ main(int argc, char **argv)
 	    "va = %12g ms^2  max = %12g ms\n",
 	    N, mu * 1000, va * 1000000, max * 1000);
 #endif
-
-	/* Clean up network layer. */
-	network_fini();
 
 #ifdef PROFILE
 	/*

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -190,6 +190,12 @@ bsdtar_atexit(void)
 	/* Free strings allocated by strdup. */
 	free(bsdtar->cachedir);
 	free(bsdtar->homedir);
+
+	/* Free matching and (if applicable) substitution patterns. */
+	cleanup_exclusions(bsdtar);
+#if HAVE_REGEX_H
+	cleanup_substitution(bsdtar);
+#endif
 }
 
 int
@@ -1007,11 +1013,6 @@ main(int argc, char **argv)
 		tarsnap_mode_x(bsdtar);
 		break;
 	}
-
-	cleanup_exclusions(bsdtar);
-#if HAVE_REGEX_H
-	cleanup_substitution(bsdtar);
-#endif
 
 #ifdef DEBUG_SELECTSTATS
 	double N, mu, va, max;


### PR DESCRIPTION
Since we've got the `atexit` function now, we might as well use it properly.  This clears up some memory leaks when calling `bsdtar_errc` within parts of the code.