### PR TITLE
Replace malloc(x*y) with imalloc(x,y) which gives us a free integer o…

### DIFF
--- a/recrypt/recrypt.c
+++ b/recrypt/recrypt.c
@@ -15,6 +15,7 @@
 #include "tarsnap_opt.h"
 #include "tsnetwork.h"
 #include "warnp.h"
+#include "imalloc.h"
 
 /* Copy batches of 16384 blocks; print a . per 512 blocks. */
 #define BATCHLEN 16384
@@ -182,7 +183,7 @@ getblist(uint64_t mnum, struct block ** blist, size_t * blistlen)
 
 	/* Allocate array of blocks. */
 	*blistlen = nfiles_m + nfiles_i + nfiles_c;
-	if ((*blist = malloc(*blistlen * sizeof(struct block))) == NULL) {
+	if (IMALLOC(*blist, *blistlen, struct block)) {
 		warnp("Cannot allocate memory");
 		exit(1);
 	}
@@ -255,7 +256,7 @@ compareblists(const struct block * oblist, size_t oblistlen,
 
 	/* Allocate space for the blocks-to-copy list. */
 	*cblistlen = oblistlen - nblistlen;
-	if ((*cblist = malloc(*cblistlen * sizeof(struct block))) == NULL) {
+	if (IMALLOC(*cblist, *cblistlen, struct block)) {
 		warnp("Cannot allocate memory");
 		exit(1);
 	}


### PR DESCRIPTION
…verflow check for little performance cost.