### PR TITLE
dry-run - manpage hint

### DIFF
--- a/tar/tarsnap.1-man.in
+++ b/tar/tarsnap.1-man.in
@@ -274,7 +274,13 @@ within a few kB or a fraction of a percent) to if
 \fB\%tarsnap\fP
 is run without the
 \fB\--dry-run\fP
-option.
+option.  Requires unsetting
+the 
+.Nm cachedir 
+and 
+.Nm keyfile
+entries in the configuration file if tarsnap-keygen was
+never run (i.e. there is no valid tarsnap key).
 .PP
 Note that the
 \fB\--maxbw\fP

--- a/tar/tarsnap.1-mdoc.in
+++ b/tar/tarsnap.1-mdoc.in
@@ -268,7 +268,13 @@ within a few kB or a fraction of a percent) to if
 .Nm
 is run without the
 .Fl -dry-run
-option.
+option.  Requires unsetting
+the  
+.Nm cachedir 
+and 
+.Nm keyfile
+entries in the configuration file if tarsnap-keygen was
+never run (i.e. there is no valid tarsnap key).
 .Pp
 Note that the
 .Fl -maxbw


### PR DESCRIPTION
In a total greenfield situation - a valid tarsnap.conf may contain key and cachedir entries that stop the --dry-run flag from working.