### PR TITLE
CSV file print stats

### DIFF
--- a/misc/bash_completion.d/tarsnap
+++ b/misc/bash_completion.d/tarsnap
@@ -43,7 +43,7 @@ _tarsnap ()
 	# They won't be completed at all.
 	wotherarg="--checkpoint-bytes|--exclude|-f|--include|--maxbw|--maxbw-rate|
 		   |--maxbw-rate-down|--maxbw-rate-up|--newer|--newer-mtime|-s|
-		   |--strip-components|--disk-pause|--creationtime"
+		   |--strip-components|--disk-pause|--creationtime|--csv-file"
 
 	# Available long options
 	longopts="--list-archives --print-stats --fsck --nuke --aggressive-networking \

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -147,6 +147,7 @@ bsdtar_init(void)
 	bsdtar->pending_chdir = NULL;
 	bsdtar->names_from_file = NULL;
 	bsdtar->modestr = NULL;
+	bsdtar->option_csv_filename = NULL;
 	bsdtar->configfiles = NULL;
 	bsdtar->archive = NULL;
 	bsdtar->progname = NULL;
@@ -190,6 +191,7 @@ bsdtar_atexit(void)
 	/* Free strings allocated by strdup. */
 	free(bsdtar->cachedir);
 	free(bsdtar->homedir);
+	free(bsdtar->option_csv_filename);
 
 	/* Free matching and (if applicable) substitution patterns. */
 	cleanup_exclusions(bsdtar);
@@ -377,6 +379,14 @@ main(int argc, char **argv)
 				bsdtar_errc(bsdtar, 1, 0,
 				    "Invalid --creationtime argument: %s",
 				    bsdtar->optarg);
+			break;
+		case OPTION_CSV_FILE: /* tarsnap */
+			if (bsdtar->option_csv_filename != NULL)
+				bsdtar_errc(bsdtar, 1, errno,
+				    "Two --csv-file options given.\n");
+			if ((bsdtar->option_csv_filename = strdup(
+			    bsdtar->optarg)) == NULL)
+				bsdtar_errc(bsdtar, 1, errno, "Out of memory");
 			break;
 		case 'd': /* multitar */
 			set_mode(bsdtar, opt, "-d");

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -68,6 +68,7 @@ struct bsdtar {
 	char		  symlink_mode; /* H or L, per BSD conventions */
 	char		  option_absolute_paths; /* -P */
 	char		  option_chroot; /* --chroot */
+	char		 *option_csv_filename; /* --csv-filename */
 	char		  option_dont_traverse_mounts; /* --one-file-system */
 	char		  option_dryrun; /* --dry-run */
 	char		  option_fast_read; /* --fast-read */
@@ -166,6 +167,7 @@ enum {
 	OPTION_CHROOT,
 	OPTION_CONFIGFILE,
 	OPTION_CREATIONTIME,
+	OPTION_CSV_FILE,
 	OPTION_DISK_PAUSE,
 	OPTION_DRYRUN,
 	OPTION_EXCLUDE,

--- a/tar/chunks/chunks.h
+++ b/tar/chunks/chunks.h
@@ -81,11 +81,11 @@ int chunks_write_chunkref(CHUNKS_W *, const uint8_t *);
 void chunks_write_extrastats(CHUNKS_W *, size_t);
 
 /**
- * chunks_write_printstats(stream, C):
+ * chunks_write_printstats(stream, C, csv):
  * Print statistics for the write transaction associated with the cookie
- * ${C} to ${stream}.
+ * ${C} to ${stream}, optionally in ${csv} format.
  */
-int chunks_write_printstats(FILE *, CHUNKS_W *);
+int chunks_write_printstats(FILE *, CHUNKS_W *, int);
 
 /**
  * chunks_write_checkpoint(C):
@@ -131,12 +131,12 @@ int chunks_delete_chunk(CHUNKS_D *, const uint8_t *);
 void chunks_delete_extrastats(CHUNKS_D *, size_t);
 
 /**
- * chunks_delete_printstats(stream, C, name):
+ * chunks_delete_printstats(stream, C, name, csv):
  * Print statistics for the delete transaction associated with the cookie
- * ${C} to ${stream}.  If ${name} is non-NULL, use it to identify the archive
- * being deleted.
+ * ${C} to ${stream}, optionally in ${csv} format.  If ${name} is non-NULL,
+ * use it to identify the archive being deleted.
  */
-int chunks_delete_printstats(FILE *, CHUNKS_D *, const char *);
+int chunks_delete_printstats(FILE *, CHUNKS_D *, const char *, int);
 
 /**
  * chunks_delete_end(C):
@@ -197,16 +197,18 @@ CHUNKS_S * chunks_stats_init(const char *);
 size_t chunks_stats_getdirsz(CHUNKS_S *);
 
 /**
- * chunks_stats_printglobal(stream, C):
- * Print global statistics relating to a set of archives.
+ * chunks_stats_printglobal(stream, C, csv):
+ * Print global statistics relating to a set of archives, optionally in ${csv}
+ * format.
  */
-int chunks_stats_printglobal(FILE *, CHUNKS_S *);
+int chunks_stats_printglobal(FILE *, CHUNKS_S *, int);
 
 /**
- * chunks_stats_printarchive(stream, C, name):
- * Print accumulated statistics for an archive with the given name.
+ * chunks_stats_printarchive(stream, C, name, csv):
+ * Print accumulated statistics for an archive with the given name, optionally
+ * in ${csv} format.
  */
-int chunks_stats_printarchive(FILE *, CHUNKS_S *, const char *);
+int chunks_stats_printarchive(FILE *, CHUNKS_S *, const char *, int);
 
 /**
  * chunks_stats_free(C):

--- a/tar/chunks/chunks.h
+++ b/tar/chunks/chunks.h
@@ -203,7 +203,7 @@ size_t chunks_stats_getdirsz(CHUNKS_S *);
 int chunks_stats_printglobal(FILE *, CHUNKS_S *);
 
 /**
- * chunks_stats_print(stream, C, name):
+ * chunks_stats_printarchive(stream, C, name):
  * Print accumulated statistics for an archive with the given name.
  */
 int chunks_stats_printarchive(FILE *, CHUNKS_S *, const char *);

--- a/tar/chunks/chunks_delete.c
+++ b/tar/chunks/chunks_delete.c
@@ -146,13 +146,14 @@ chunks_delete_extrastats(CHUNKS_D * C, size_t len)
 }
 
 /**
- * chunks_delete_printstats(stream, C, name):
+ * chunks_delete_printstats(stream, C, name, csv):
  * Print statistics for the delete transaction associated with the cookie
- * ${C} to ${stream}.  If ${name} is non-NULL, use it to identify the archive
- * being deleted.
+ * ${C} to ${stream}, optionally in ${csv} format.  If ${name} is non-NULL,
+ * use it to identify the archive being deleted.
  */
 int
-chunks_delete_printstats(FILE * stream, CHUNKS_D * C, const char * name)
+chunks_delete_printstats(FILE * stream, CHUNKS_D * C, const char * name,
+    int csv)
 {
 
 	/* If we don't have an archive name, call it "This archive". */
@@ -160,21 +161,21 @@ chunks_delete_printstats(FILE * stream, CHUNKS_D * C, const char * name)
 		name = "This archive";
 
 	/* Print header. */
-	if (chunks_stats_printheader(stream))
+	if (chunks_stats_printheader(stream, csv))
 		goto err0;
 
 	/* Print the statistics we have. */
 	if (chunks_stats_print(stream, &C->stats_total, "All archives",
-	    &C->stats_extra))
+	    &C->stats_extra, csv))
 		goto err0;
 	if (chunks_stats_print(stream, &C->stats_unique, "  (unique data)",
-	    &C->stats_extra))
+	    &C->stats_extra, csv))
 		goto err0;
 	if (chunks_stats_print(stream, &C->stats_tape, name,
-	    &C->stats_tapee))
+	    &C->stats_tapee, csv))
 		goto err0;
 	if (chunks_stats_print(stream, &C->stats_freed, "Deleted data",
-	    &C->stats_tapee))
+	    &C->stats_tapee, csv))
 		goto err0;
 
 	/* Success! */

--- a/tar/chunks/chunks_internal.h
+++ b/tar/chunks/chunks_internal.h
@@ -97,17 +97,18 @@ void chunks_stats_add(struct chunkstats *, size_t len, size_t zlen,
 void chunks_stats_addstats(struct chunkstats *, struct chunkstats *);
 
 /**
- * chunks_stats_printheader(stream):
- * Print a header line for statistics to ${stream}.
+ * chunks_stats_printheader(stream, csv):
+ * Print a header line for statistics to ${stream}, optionally in ${csv}
+ * format.
  */
-int chunks_stats_printheader(FILE *);
+int chunks_stats_printheader(FILE *, int);
 
 /**
- * chunks_stats_print(stream, stats, name, stats_extra):
+ * chunks_stats_print(stream, stats, name, stats_extra, csv):
  * Print a line with ${name} and combined statistics from ${stats} and
- * ${stats_extra} to ${stream}.
+ * ${stats_extra} to ${stream}, optionally in ${csv} format.
  */
 int chunks_stats_print(FILE *, struct chunkstats *, const char *,
-    struct chunkstats *);
+    struct chunkstats *, int);
 
 #endif /* !_CHUNKS_INTERNAL_H_ */

--- a/tar/chunks/chunks_stats.c
+++ b/tar/chunks/chunks_stats.c
@@ -274,23 +274,23 @@ chunks_stats_getdirsz(CHUNKS_S * C)
 }
 
 /**
- * chunks_stats_printglobal(stream, C):
- * Print global statistics relating to a set of archives.
+ * chunks_stats_printglobal(stream, C, csv):
+ * Print global statistics relating to a set of archives, optionally in ${csv}
+ * format.
  */
 int
-chunks_stats_printglobal(FILE * stream, CHUNKS_S * C)
+chunks_stats_printglobal(FILE * stream, CHUNKS_S * C, int csv)
 {
-
 	/* Print header. */
-	if (chunks_stats_printheader(stream))
+	if (chunks_stats_printheader(stream, csv))
 		goto err0;
 
 	/* Print the global statistics. */
 	if (chunks_stats_print(stream, &C->stats_total, "All archives",
-	    &C->stats_extra))
+	    &C->stats_extra, csv))
 		goto err0;
 	if (chunks_stats_print(stream, &C->stats_unique, "  (unique data)",
-	    &C->stats_extra))
+	    &C->stats_extra, csv))
 		goto err0;
 
 	/* Success! */
@@ -371,18 +371,20 @@ chunks_stats_extrastats(CHUNKS_S * C, size_t len)
 }
 
 /**
- * chunks_stats_printarchive(stream, C, name):
- * Print accumulated statistics for an archive with the given name.
+ * chunks_stats_printarchive(stream, C, name, csv):
+ * Print accumulated statistics for an archive with the given name, optionally
+ * in ${csv} format.
  */
 int
-chunks_stats_printarchive(FILE * stream, CHUNKS_S * C, const char * name)
+chunks_stats_printarchive(FILE * stream, CHUNKS_S * C, const char * name,
+    int csv)
 {
-
 	/* Print statistics for this archive. */
-	if (chunks_stats_print(stream, &C->stats_tape, name, &C->stats_tapee))
+	if (chunks_stats_print(stream, &C->stats_tape, name,
+	    &C->stats_tapee, csv))
 		goto err0;
 	if (chunks_stats_print(stream, &C->stats_tapeu, "  (unique data)",
-	    &C->stats_tapee))
+	    &C->stats_tapee, csv))
 		goto err0;
 
 	/* Success! */

--- a/tar/chunks/chunks_stats_internal.c
+++ b/tar/chunks/chunks_stats_internal.c
@@ -53,11 +53,12 @@ chunks_stats_addstats(struct chunkstats * to, struct chunkstats * from)
 }
 
 /**
- * chunks_stats_printheader(stream):
- * Print a header line for statistics to ${stream}.
+ * chunks_stats_printheader(stream, csv):
+ * Print a header line for statistics to ${stream}, optionally in ${csv}
+ * format.
  */
 int
-chunks_stats_printheader(FILE * stream)
+chunks_stats_printheader(FILE * stream, int csv)
 {
 
 #ifdef STATS_WITH_CHUNKS
@@ -80,13 +81,13 @@ err0:
 }
 
 /**
- * chunks_stats_print(stream, stats, name, stats_extra):
+ * chunks_stats_print(stream, stats, name, stats_extra, csv):
  * Print a line with ${name} and combined statistics from ${stats} and
- * ${stats_extra} to ${stream}.
+ * ${stats_extra} to ${stream}, optionally in ${csv} format.
  */
 int
 chunks_stats_print(FILE * stream, struct chunkstats * stats,
-    const char * name, struct chunkstats * stats_extra)
+    const char * name, struct chunkstats * stats_extra, int csv)
 {
 	struct chunkstats s;
 	char * s_lenstr, * s_zlenstr;

--- a/tar/chunks/chunks_write.c
+++ b/tar/chunks/chunks_write.c
@@ -244,30 +244,30 @@ chunks_write_extrastats(CHUNKS_W * C, size_t len)
 }
 
 /**
- * chunks_write_printstats(stream, C):
+ * chunks_write_printstats(stream, C, csv):
  * Print statistics for the write transaction associated with the cookie
- * ${C} to ${stream}.
+ * ${C} to ${stream}, optionally in ${csv} format.
  */
 int
-chunks_write_printstats(FILE * stream, CHUNKS_W * C)
+chunks_write_printstats(FILE * stream, CHUNKS_W * C, int csv)
 {
 
 	/* Print header. */
-	if (chunks_stats_printheader(stream))
+	if (chunks_stats_printheader(stream, csv))
 		goto err0;
 
 	/* Print the statistics we have. */
 	if (chunks_stats_print(stream, &C->stats_total, "All archives",
-	    &C->stats_extra))
+	    &C->stats_extra, csv))
 		goto err0;
 	if (chunks_stats_print(stream, &C->stats_unique, "  (unique data)",
-	    &C->stats_extra))
+	    &C->stats_extra, csv))
 		goto err0;
 	if (chunks_stats_print(stream, &C->stats_tape, "This archive",
-	    &C->stats_tapee))
+	    &C->stats_tapee, csv))
 		goto err0;
 	if (chunks_stats_print(stream, &C->stats_new, "New data",
-	    &C->stats_tapee))
+	    &C->stats_tapee, csv))
 		goto err0;
 
 	/* Success! */

--- a/tar/cmdline.c
+++ b/tar/cmdline.c
@@ -78,6 +78,7 @@ static struct option {
 	{ "confirmation",         0, 'w' },
 	{ "create",               0, 'c' },
 	{ "creationtime",         1, OPTION_CREATIONTIME },
+	{ "csv-file",		  1, OPTION_CSV_FILE },
 	{ "dereference",	  0, 'L' },
 	{ "directory",            1, 'C' },
 	{ "disk-pause",		  1, OPTION_DISK_PAUSE },

--- a/tar/glue/archive_multitape.c
+++ b/tar/glue/archive_multitape.c
@@ -114,17 +114,19 @@ archive_read_open_multitape(struct archive * a, uint64_t machinenum,
 
 /**
  * archive_write_open_multitape(a, machinenum, cachedir, tapename, argc,
- *     argv, printstats, dryrun, creationtime):
+ *     argv, printstats, dryrun, creationtime, csv_filename):
  * Open the multitape tape ${tapename} for writing and associate it with the
  * archive $a$.  If ${printstats} is non-zero, print archive statistics when
  * the tape is closed.  If ${dryrun} is non-zero, perform a dry run.
  * Record ${creationtime} as the creation time in the archive metadata.
+ * If ${csv_filename} is given, write statistics in CSV format.
  * Return a cookie which can be passed to the multitape layer.
  */
 void *
 archive_write_open_multitape(struct archive * a, uint64_t machinenum,
     const char * cachedir, const char * tapename, int argc,
-    char ** argv, int printstats, int dryrun, time_t creationtime)
+    char ** argv, int printstats, int dryrun, time_t creationtime,
+    const char * csv_filename)
 {
 	struct multitape_write_internal * d;
 
@@ -132,7 +134,8 @@ archive_write_open_multitape(struct archive * a, uint64_t machinenum,
 	archive_clear_error(a);
 
 	if ((d = writetape_open(machinenum, cachedir, tapename,
-	    argc, argv, printstats, dryrun, creationtime)) == NULL) {
+	    argc, argv, printstats, dryrun, creationtime,
+	    csv_filename)) == NULL) {
 		archive_set_error(a, errno, "Error creating new archive");
 		return (NULL);
 	}

--- a/tar/glue/archive_multitape.h
+++ b/tar/glue/archive_multitape.h
@@ -12,15 +12,16 @@ void * archive_read_open_multitape(struct archive *, uint64_t, const char *);
 
 /**
  * archive_write_open_multitape(a, machinenum, cachedir, tapename, argc,
- *     argv, printstats, dryrun, creationtime):
+ *     argv, printstats, dryrun, creationtime, csv_filename):
  * Open the multitape tape ${tapename} for writing and associate it with the
  * archive $a$.  If ${printstats} is non-zero, print archive statistics when
  * the tape is closed.  If ${dryrun} is non-zero, perform a dry run.
  * Record ${creationtime} as the creation time in the archive metadata.
+ * If ${csv_filename} is given, write statistics in CSV format.
  * Return a cookie which can be passed to the multitape layer.
  */
 void * archive_write_open_multitape(struct archive *, uint64_t, const char *,
-    const char *, int argc, char ** argv, int, int, time_t);
+    const char *, int argc, char ** argv, int, int, time_t, const char *);
 
 /**
  * archive_write_multitape_setmode(a, cookie, mode):

--- a/tar/glue/tape.c
+++ b/tar/glue/tape.c
@@ -136,7 +136,7 @@ tarsnap_mode_print_stats(struct bsdtar *bsdtar)
 	} else {
 		/* User wants statistics about specific archive(s). */
 		for (i = 0; i < bsdtar->ntapes; i++) {
-			switch (statstape_print(d, bsdtar->tapenames[i])) {
+			switch (statstape_print(d, bsdtar->tapenames[i], NULL)) {
 			case 0:
 				break;
 			case 1:

--- a/tar/glue/tape.c
+++ b/tar/glue/tape.c
@@ -31,7 +31,7 @@ tarsnap_mode_d(struct bsdtar *bsdtar)
 			    bsdtar->tapenames[i]);
 		switch (deletetape(d, bsdtar->machinenum, bsdtar->cachedir,
 		    bsdtar->tapenames[i], bsdtar->option_print_stats,
-		    bsdtar->ntapes > 1 ? 1 : 0)) {
+		    bsdtar->ntapes > 1 ? 1 : 0, NULL)) {
 		case 0:
 			break;
 		case 1:

--- a/tar/glue/tape.c
+++ b/tar/glue/tape.c
@@ -131,7 +131,7 @@ tarsnap_mode_print_stats(struct bsdtar *bsdtar)
 	} else if ((bsdtar->tapenames[0][0] == '*') &&
 	    (bsdtar->tapenames[0][1] == '\0')) {
 		/* User wants statistics on all archives. */
-		if (statstape_printall(d))
+		if (statstape_printall(d, NULL))
 			goto err2;
 	} else {
 		/* User wants statistics about specific archive(s). */

--- a/tar/glue/tape.c
+++ b/tar/glue/tape.c
@@ -123,7 +123,7 @@ tarsnap_mode_print_stats(struct bsdtar *bsdtar)
 		goto err1;
 
 	/* Print statistics about the archive set. */
-	if (statstape_printglobal(d))
+	if (statstape_printglobal(d, NULL))
 		goto err2;
 
 	if (bsdtar->ntapes == 0) {

--- a/tar/glue/tape.c
+++ b/tar/glue/tape.c
@@ -31,7 +31,7 @@ tarsnap_mode_d(struct bsdtar *bsdtar)
 			    bsdtar->tapenames[i]);
 		switch (deletetape(d, bsdtar->machinenum, bsdtar->cachedir,
 		    bsdtar->tapenames[i], bsdtar->option_print_stats,
-		    bsdtar->ntapes > 1 ? 1 : 0, NULL)) {
+		    bsdtar->ntapes > 1 ? 1 : 0, bsdtar->option_csv_filename)) {
 		case 0:
 			break;
 		case 1:
@@ -123,7 +123,7 @@ tarsnap_mode_print_stats(struct bsdtar *bsdtar)
 		goto err1;
 
 	/* Print statistics about the archive set. */
-	if (statstape_printglobal(d, NULL))
+	if (statstape_printglobal(d, bsdtar->option_csv_filename))
 		goto err2;
 
 	if (bsdtar->ntapes == 0) {
@@ -131,12 +131,13 @@ tarsnap_mode_print_stats(struct bsdtar *bsdtar)
 	} else if ((bsdtar->tapenames[0][0] == '*') &&
 	    (bsdtar->tapenames[0][1] == '\0')) {
 		/* User wants statistics on all archives. */
-		if (statstape_printall(d, NULL))
+		if (statstape_printall(d, bsdtar->option_csv_filename))
 			goto err2;
 	} else {
 		/* User wants statistics about specific archive(s). */
 		for (i = 0; i < bsdtar->ntapes; i++) {
-			switch (statstape_print(d, bsdtar->tapenames[i], NULL)) {
+			switch (statstape_print(d, bsdtar->tapenames[i],
+			    bsdtar->option_csv_filename)) {
 			case 0:
 				break;
 			case 1:

--- a/tar/multitape/multitape.h
+++ b/tar/multitape/multitape.h
@@ -50,12 +50,12 @@ int readtape_close(TAPE_R *);
 
 /**
  * writetape_open(machinenum, cachedir, tapename, argc, argv, printstats,
- *     dryrun, creationtime):
+ *     dryrun, creationtime, csv_filename):
  * Create a tape with the given name, and return a cookie which can be used
  * for accessing it.  The argument vector must be long-lived.
  */
 TAPE_W * writetape_open(uint64_t, const char *, const char *, int, char **,
-    int, int, time_t);
+    int, int, time_t, const char *);
 
 /**
  * writetape_setcallbacks(d, callback_chunk, callback_trailer,

--- a/tar/multitape/multitape.h
+++ b/tar/multitape/multitape.h
@@ -175,11 +175,13 @@ int statstape_printall(TAPE_S *);
 int statstape_printlist(TAPE_S *, int);
 
 /**
- * statstape_print(d, tapename):
+ * statstape_print(d, tapename, csv_filename):
  * Print statistics relating to a specific archive in a set.  Return 0 on
- * success, 1 if the tape does not exist, or -1 on other errors.
+ * success, 1 if the tape does not exist, or -1 on other errors.  If
+ * ${csv_filename} is not NULL, output will be written in CSV format to that
+ * filename.
  */
-int statstape_print(TAPE_S *, const char *);
+int statstape_print(TAPE_S *, const char *, const char *);
 
 /**
  * statstape_close(d):

--- a/tar/multitape/multitape.h
+++ b/tar/multitape/multitape.h
@@ -161,10 +161,12 @@ TAPE_S * statstape_open(uint64_t, const char *);
 int statstape_printglobal(TAPE_S *, const char *);
 
 /**
- * statstape_printall(d):
- * Print statistics relating to each of the archives in a set.
+ * statstape_printall(d, csv_filename):
+ * Print statistics relating to each of the archives in a set.  If
+ * ${csv_filename} is not NULL, output will be written in CSV format to that
+ * filename.
  */
-int statstape_printall(TAPE_S *);
+int statstape_printall(TAPE_S *, const char *);
 
 /**
  * statstape_printlist(d, verbose):

--- a/tar/multitape/multitape.h
+++ b/tar/multitape/multitape.h
@@ -154,10 +154,11 @@ void deletetape_free(TAPE_D *);
 TAPE_S * statstape_open(uint64_t, const char *);
 
 /**
- * statstape_printglobal(d):
- * Print global statistics relating to a set of archives.
+ * statstape_printglobal(d, csv_filename):
+ * Print global statistics relating to a set of archives.  If ${csv_filename}
+ * is not NULL, output will be written in CSV format to that filename.
  */
-int statstape_printglobal(TAPE_S *);
+int statstape_printglobal(TAPE_S *, const char *);
 
 /**
  * statstape_printall(d):

--- a/tar/multitape/multitape.h
+++ b/tar/multitape/multitape.h
@@ -132,13 +132,16 @@ void writetape_free(TAPE_W *);
 TAPE_D * deletetape_init(uint64_t);
 
 /**
- * deletetape(d, machinenum, cachedir, tapename, printstats, withname):
+ * deletetape(d, machinenum, cachedir, tapename, printstats, withname,
+ *     csv_filename):
  * Delete the specified tape, and print statistics to stderr if requested.
  * If ${withname} is non-zero, print statistics with the archive name, not
  * just as "This archive".  Return 0 on success, 1 if the tape does not exist,
- * or -1 on other errors.
+ * or -1 on other errors.  If ${csv_filename} is specified, output in CSV
+ * format instead of to stderr.
  */
-int deletetape(TAPE_D *, uint64_t, const char *, const char *, int, int);
+int deletetape(TAPE_D *, uint64_t, const char *, const char *, int, int,
+    const char *);
 
 /**
  * deletetape_free(d):

--- a/tar/multitape/multitape_delete.c
+++ b/tar/multitape/multitape_delete.c
@@ -60,15 +60,18 @@ err0:
 }
 
 /**
- * deletetape(d, machinenum, cachedir, tapename, printstats, withname):
+ * deletetape(d, machinenum, cachedir, tapename, printstats, withname,
+ *     csv_filename):
  * Delete the specified tape, and print statistics to stderr if requested.
  * If ${withname} is non-zero, print statistics with the archive name, not
  * just as "This archive".  Return 0 on success, 1 if the tape does not exist,
- * or -1 on other errors.
+ * or -1 on other errors.  If ${csv_filename} is specified, output in CSV
+ * format instead of to stderr.
  */
 int
 deletetape(TAPE_D * d, uint64_t machinenum, const char * cachedir,
-    const char * tapename, int printstats, int withname)
+    const char * tapename, int printstats, int withname,
+    const char * csv_filename)
 {
 	struct tapemetadata tmd;
 	CHUNKS_D * C;		/* Chunk layer delete cookie. */
@@ -78,6 +81,12 @@ deletetape(TAPE_D * d, uint64_t machinenum, const char * cachedir,
 	uint8_t lastseq[32];
 	uint8_t seqnum[32];
 	int rc = -1;		/* Presume error was not !found. */
+	FILE * output = stderr;
+	int csv = 0;
+
+	/* Should we output to a CSV file? */
+	if (csv_filename != NULL)
+		csv = 1;
 
 	/* Lock the cache directory. */
 	if ((lockfd = multitape_lock(cachedir)) == -1)
@@ -113,15 +122,15 @@ deletetape(TAPE_D * d, uint64_t machinenum, const char * cachedir,
 
 	/* Delete chunks. */
 	if (multitape_chunkiter_tmd(SR, NULL, &tmd, callback_delete, C, 0))
-		goto err4;
+		goto err5;
 
 	/* Delete archive index. */
 	if (multitape_metaindex_delete(S, C, &tmd))
-		goto err4;
+		goto err5;
 
 	/* Delete archive metadata. */
 	if (multitape_metadata_delete(S, C, &tmd))
-		goto err4;
+		goto err5;
 
 	/* Free tape metadata. */
 	multitape_metadata_free(&tmd);
@@ -131,9 +140,18 @@ deletetape(TAPE_D * d, uint64_t machinenum, const char * cachedir,
 		goto err3;
 
 	/* Print statistics if they were requested. */
-	if ((printstats != 0) &&
-	    chunks_delete_printstats(stderr, C, withname ? tapename : NULL, 0))
-		goto err3;
+	if (printstats != 0) {
+		if (csv && (output = fopen(csv_filename, "wt")) == NULL)
+			goto err3;
+
+		/* Actually print statistics. */
+	    	if (chunks_delete_printstats(output, C,
+		    withname ? tapename : NULL, csv))
+			goto err4;
+
+		if (csv && fclose(output))
+			goto err3;
+	}
 
 	/* Close storage and chunk layer cookies. */
 	if (chunks_delete_end(C))
@@ -151,8 +169,11 @@ deletetape(TAPE_D * d, uint64_t machinenum, const char * cachedir,
 	/* Success! */
 	return (0);
 
-err4:
+err5:
 	multitape_metadata_free(&tmd);
+err4:
+	if (output != stderr)
+		fclose(output);
 err3:
 	chunks_delete_free(C);
 err2:

--- a/tar/multitape/multitape_delete.c
+++ b/tar/multitape/multitape_delete.c
@@ -132,7 +132,7 @@ deletetape(TAPE_D * d, uint64_t machinenum, const char * cachedir,
 
 	/* Print statistics if they were requested. */
 	if ((printstats != 0) &&
-	    chunks_delete_printstats(stderr, C, withname ? tapename : NULL))
+	    chunks_delete_printstats(stderr, C, withname ? tapename : NULL, 0))
 		goto err3;
 
 	/* Close storage and chunk layer cookies. */

--- a/tar/multitape/multitape_stats.c
+++ b/tar/multitape/multitape_stats.c
@@ -99,7 +99,7 @@ statstape_printglobal(TAPE_S * d)
 {
 
 	/* Ask the chunk storage layer to do this. */
-	if (chunks_stats_printglobal(stdout, d->C))
+	if (chunks_stats_printglobal(stdout, d->C, 0))
 		goto err0;
 
 	/* Success! */
@@ -145,7 +145,7 @@ statstape_printall(TAPE_S * d)
 			goto err2;
 
 		/* Print the statistics. */
-		if (chunks_stats_printarchive(stdout, d->C, tmd.name))
+		if (chunks_stats_printarchive(stdout, d->C, tmd.name, 0))
 			goto err2;
 
 		/* Free parsed metadata. */
@@ -290,7 +290,7 @@ statstape_print(TAPE_S * d, const char * tapename)
 	multitape_metadata_free(&tmd);
 
 	/* Print the statistics. */
-	if (chunks_stats_printarchive(stdout, d->C, tapename))
+	if (chunks_stats_printarchive(stdout, d->C, tapename, 0))
 		goto err0;
 
 	/* Success! */

--- a/tar/multitape/multitape_write.c
+++ b/tar/multitape/multitape_write.c
@@ -905,7 +905,7 @@ writetape_close(TAPE_W * d)
 		goto err2;
 
 	/* Print statistics, if we've been asked to do so. */
-	if (d->stats_enabled && chunks_write_printstats(stderr, d->C))
+	if (d->stats_enabled && chunks_write_printstats(stderr, d->C, 0))
 		goto err2;
 
 	/* Ask the chunks layer to prepare for a checkpoint. */

--- a/tar/multitape/multitape_write.c
+++ b/tar/multitape/multitape_write.c
@@ -56,6 +56,7 @@ struct multitape_write_internal {
 	char ** argv;		/* Command-line arguments. */
 	int stats_enabled;	/* Stats printed on close. */
 	int eof;		/* Tape is truncated at current position. */
+	const char * csv_filename;	/* Print statistics to a CSV file. */
 
 	/* Lower level cookies. */
 	STORAGE_W * S;		/* Storage layer write cookie; NULL=dryrun. */
@@ -386,14 +387,14 @@ err0:
 
 /**
  * writetape_open(machinenum, cachedir, tapename, argc, argv, printstats,
- *     dryrun, creationtime):
+ *     dryrun, creationtime, csv_filename):
  * Create a tape with the given name, and return a cookie which can be used
  * for accessing it.  The argument vector must be long-lived.
  */
 TAPE_W *
 writetape_open(uint64_t machinenum, const char * cachedir,
     const char * tapename, int argc, char ** argv, int printstats,
-    int dryrun, time_t creationtime)
+    int dryrun, time_t creationtime, const char * csv_filename)
 {
 	struct multitape_write_internal * d;
 	uint8_t lastseq[32];
@@ -438,6 +439,9 @@ writetape_open(uint64_t machinenum, const char * cachedir,
 
 	/* Record whether we should print archive statistics on close. */
 	d->stats_enabled = printstats;
+
+	/* Record whether to print statistics to a CSV file. */
+	d->csv_filename = csv_filename;
 
 	/* If we're using a cache, make sure ${cachedir} exists. */
 	if ((cachedir != NULL) && (dirutil_needdir(cachedir)))
@@ -880,6 +884,12 @@ err0:
 int
 writetape_close(TAPE_W * d)
 {
+	FILE * output = stderr;
+	int csv = 0;
+
+	/* Should we output to a CSV file? */
+	if (d->csv_filename != NULL)
+		csv = 1;
 
 	/* If the archive is truncated, end any current archive entry. */
 	if (d->eof && (d->mode < 2) && writetape_setmode(d, 2))
@@ -905,8 +915,14 @@ writetape_close(TAPE_W * d)
 		goto err2;
 
 	/* Print statistics, if we've been asked to do so. */
-	if (d->stats_enabled && chunks_write_printstats(stderr, d->C, 0))
-		goto err2;
+	if (d->stats_enabled) {
+		if (csv && (output = fopen(d->csv_filename, "wt")) == NULL)
+			goto err2;
+		if (chunks_write_printstats(output, d->C, csv))
+			goto err3;
+		if (csv && fclose(output))
+			goto err2;
+	}
 
 	/* Ask the chunks layer to prepare for a checkpoint. */
 	if (chunks_write_checkpoint(d->C))
@@ -945,6 +961,9 @@ writetape_close(TAPE_W * d)
 	/* Success! */
 	return (0);
 
+err3:
+	if (output != stderr)
+		fclose(output);
 err2:
 	chunks_write_free(d->C);
 	storage_write_free(d->S);

--- a/tar/tarsnap.1-man.in
+++ b/tar/tarsnap.1-man.in
@@ -249,6 +249,10 @@ Manually specify a creation time (a unix timestamp) for the
 archive.  This is unlikely to be useful when tarsnap is being
 invoked directly from the command line.
 .TP
+\fB\--csv-file\fP \fIX\fP
+(only relevant with --print-stats)
+Write statistics in CSV format to a file.
+.TP
 \fB\--disk-pause\fP \fIX\fP
 (c mode only)
 Pause for

--- a/tar/tarsnap.1-mdoc.in
+++ b/tar/tarsnap.1-mdoc.in
@@ -244,6 +244,9 @@ take priority.
 Manually specify a creation time (a unix timestamp) for the
 archive.  This is unlikely to be useful when tarsnap is being
 invoked directly from the command line.
+.It Fl -csv-file Ar X
+(only relevant with --print-stats)
+Write statistics in CSV format to a file.
 .It Fl -disk-pause Ar X
 (c mode only)
 Pause for

--- a/tar/write.c
+++ b/tar/write.c
@@ -286,7 +286,7 @@ tarsnap_mode_c(struct bsdtar *bsdtar)
 	    bsdtar->machinenum, bsdtar->cachedir, bsdtar->tapenames[0],
 	    bsdtar->argc_orig, bsdtar->argv_orig,
 	    bsdtar->option_print_stats, bsdtar->option_dryrun,
-	    bsdtar->creationtime);
+	    bsdtar->creationtime, NULL);
 	if (bsdtar->write_cookie == NULL) {
 		bsdtar_warnc(bsdtar, 0, "%s", archive_error_string(a));
 		goto err1;

--- a/tar/write.c
+++ b/tar/write.c
@@ -286,7 +286,7 @@ tarsnap_mode_c(struct bsdtar *bsdtar)
 	    bsdtar->machinenum, bsdtar->cachedir, bsdtar->tapenames[0],
 	    bsdtar->argc_orig, bsdtar->argv_orig,
 	    bsdtar->option_print_stats, bsdtar->option_dryrun,
-	    bsdtar->creationtime, NULL);
+	    bsdtar->creationtime, bsdtar->option_csv_filename);
 	if (bsdtar->write_cookie == NULL) {
 		bsdtar_warnc(bsdtar, 0, "%s", archive_error_string(a));
 		goto err1;


### PR DESCRIPTION
To test, enable `humanize-numbers` (or not) in `~/.tarsnaprc`, then:

```
./tarsnap --print-stats --csv-file=c.csv -c -f csv ~/backup
./tarsnap --print-stats --csv-file=p.csv
./tarsnap --print-stats --csv-file=s.csv -f 'csv'
./tarsnap --print-stats --csv-file=a.csv -f '*'
./tarsnap --print-stats --csv-file=d.csv -f 'csv' -d
```

Adding this to archive creation was particularly annoying; since that passes through libarchive code, I had to add `csv-filename` to the TAPE_W cookie.  If you can see a cleaner way of doing this, I'm all ears and eager to refactor.