### PR TITLE
tarsnap-keyregen: Check for more than one --passphrased

### DIFF
--- a/keyregen/keyregen.c
+++ b/keyregen/keyregen.c
@@ -114,6 +114,8 @@ main(int argc, char **argv)
 			}
 			break;
 		GETOPT_OPT("--passphrased"):
+			if (passphrased != 0)
+				usage();
 			passphrased = 1;
 			break;
 		GETOPT_MISSING_ARG:


### PR DESCRIPTION
Whoops, forgot this one in tarsnap-regen.