### PR TITLE
Free upon errors in config file(s)

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -168,6 +168,7 @@ bsdtar_init(void)
 	bsdtar->siginfo = NULL;
 	bsdtar->substitution = NULL;
 	bsdtar->keyfile = NULL;
+	bsdtar->conffile = NULL;
 
 	/* We don't have bsdtar->progname yet, so we can't use bsdtar_errc. */
 	if (atexit(bsdtar_atexit)) {
@@ -194,6 +195,7 @@ bsdtar_atexit(void)
 	free(bsdtar->homedir);
 	free(bsdtar->option_csv_filename);
 	free(bsdtar->keyfile);
+	free(bsdtar->conffile);
 
 	/* Free matching and (if applicable) substitution patterns. */
 	cleanup_exclusions(bsdtar);
@@ -214,7 +216,6 @@ main(int argc, char **argv)
 	char			 buff[16];
 	char			 cachedir[PATH_MAX + 1];
 	struct passwd		*pws;
-	char			*conffile;
 	const char		*missingkey;
 	time_t			 now;
 	size_t 			 i;
@@ -770,14 +771,15 @@ main(int argc, char **argv)
 	if (bsdtar->option_no_default_config == 0) {
 		/* Process options from ~/.tarsnaprc. */
 		if (bsdtar->homedir != NULL) {
-			if (asprintf(&conffile, "%s/.tarsnaprc",
+			if (asprintf(&bsdtar->conffile, "%s/.tarsnaprc",
 			    bsdtar->homedir) == -1)
 				bsdtar_errc(bsdtar, 1, errno, "No memory");
 
-			configfile(bsdtar, conffile);
+			configfile(bsdtar, bsdtar->conffile);
 
 			/* Free string allocated by asprintf. */
-			free(conffile);
+			free(bsdtar->conffile);
+			bsdtar->conffile = NULL;
 		}
 
 		/* Process options from system-wide tarsnap.conf. */

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -130,6 +130,9 @@ struct bsdtar {
 	char		  warned_lead_slash; /* Already displayed warning */
 	char		  next_line_is_dir; /* Used for -C parsing in -cT */
 
+	/* Config-file parsing strings. */
+	char		 *conffile;
+
 	/* Used for --dryrun with tarsnap.conf.sample with a missing keyfile. */
 	int		  config_file_keyfile_failed;
 

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -133,6 +133,7 @@ struct bsdtar {
 	/* Config-file parsing strings. */
 	char		 *conffile;
 	char		 *conf_opt;
+	char		 *conf_arg;
 
 	/* Used for --dryrun with tarsnap.conf.sample with a missing keyfile. */
 	int		  config_file_keyfile_failed;

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -132,6 +132,7 @@ struct bsdtar {
 
 	/* Config-file parsing strings. */
 	char		 *conffile;
+	char		 *conf_opt;
 
 	/* Used for --dryrun with tarsnap.conf.sample with a missing keyfile. */
 	int		  config_file_keyfile_failed;


### PR DESCRIPTION
Makes valgrind happy if there's any problems in parsing the config file.  I'm not 100% happy with this PR since it's a bit awkward due to interfacing with libarchive code (longer comments in https://github.com/Tarsnap/tarsnap/commit/a52cd2e1220406c01a621d1116c5f3515880bda7), but it's worth bringing to your attention.