### PR TITLE
man: add --version to synopsis and description

### DIFF
--- a/tar/tarsnap.1-man.in
+++ b/tar/tarsnap.1-man.in
@@ -61,6 +61,9 @@
 \fB\%tarsnap\fP
 {\fB\--nuke\fP}
 \fB\--keyfile\fP \fIkey-file\fP
+.br
+\fB\%tarsnap\fP
+\fB\--version\fP
 .SH DESCRIPTION
 .ad l
 \fB\%tarsnap\fP
@@ -132,6 +135,11 @@ To protect against accidental data loss,
 will ask you to type the text "No Tomorrow" when using the
 \fB\--nuke\fP
 command.
+.TP
+\fB\--version\fP
+Print version number of
+\fB\%tarsnap\fP,
+and exit.
 .RE
 .PP
 In
@@ -811,7 +819,7 @@ the memory usage when
 is specified, by not caching anything.
 .TP
 \fB\--version\fP
-Print version of
+Print version number of
 \fB\%tarsnap\fP,
 and exit.
 .TP

--- a/tar/tarsnap.1-mdoc.in
+++ b/tar/tarsnap.1-mdoc.in
@@ -82,6 +82,8 @@
 .Nm
 .Brq Fl -nuke
 .Fl -keyfile Ar key-file
+.Nm
+.Fl -version
 .Sh DESCRIPTION
 .Nm
 creates, reads, deletes, and otherwise manages online backups.
@@ -141,6 +143,10 @@ To protect against accidental data loss,
 will ask you to type the text "No Tomorrow" when using the
 .Fl -nuke
 command.
+.It Fl -version
+Print version number of
+.Nm ,
+and exit.
 .El
 .Pp
 In
@@ -735,7 +741,7 @@ the memory usage when
 .Fl -lowmem
 is specified, by not caching anything.
 .It Fl -version
-Print version of
+Print version number of
 .Nm ,
 and exit.
 .It Fl w


### PR DESCRIPTION
I know that the C implementation doesn't use the `bsdtar->mode` variable to
handle `--version`, but as far as the user is concerned, it is incorrect to
write
    The first option to tarsnap is a mode indicator from the following list:
if that list does not include `--version`.