### PR TITLE
Move C preprocessor options to CPPFLAGS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,30 @@ config.log
 configure
 confinc
 confmf
+
+# ignore build-generated files
+*.a
+*.o
+.deps
+.dirstamp
+/Makefile
+/a.out.dSYM
+/config.h
+/config.status
+/cpusupport-config.h
+/stamp-h1
+
+# ignore installed files
+/keygen/tarsnap-keygen.1
+/keymgmt/tarsnap-keymgmt.1
+/keyregen/tarsnap-keyregen.1
+/recrypt/tarsnap-recrypt.1
+/tar/tarsnap.1
+/tar/tarsnap.1-mdoc
+/tar/tarsnap.conf.5
+/tar/tarsnap.conf.5-mdoc
+/tarsnap
+/tarsnap-keygen
+/tarsnap-keymgmt
+/tarsnap-keyregen
+/tarsnap-recrypt

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,7 +84,7 @@ libarchive_libarchive_a_SOURCES+=						\
 	libarchive/filter_fork_windows.c
 endif
 
-libarchive_libarchive_a_CPPFLAGS=-I $(top_builddir)/libarchive
+libarchive_libarchive_a_CPPFLAGS=-I$(top_builddir)/libarchive
 
 #
 # Tarsnap internal library code
@@ -186,7 +186,7 @@ lib_libtarsnap_a_CPPFLAGS=				\
 		-I$(top_srcdir)/libcperciva/events	\
 		-I$(top_srcdir)/libcperciva/network	\
 		-I$(top_srcdir)/libcperciva/util	\
-		-D CPUSUPPORT_CONFIG_FILE=\"cpusupport-config.h\" \
+		-DCPUSUPPORT_CONFIG_FILE=\"cpusupport-config.h\" \
 		-DPOSIXFAIL_MSG_NOSIGNAL \
 		-DPOSIXFAIL_CLOCK_REALTIME
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -186,7 +186,6 @@ lib_libtarsnap_a_CPPFLAGS=				\
 		-I$(top_srcdir)/libcperciva/events	\
 		-I$(top_srcdir)/libcperciva/network	\
 		-I$(top_srcdir)/libcperciva/util	\
-		-I.					\
 		-D CPUSUPPORT_CONFIG_FILE=\"cpusupport-config.h\" \
 		-DPOSIXFAIL_MSG_NOSIGNAL \
 		-DPOSIXFAIL_CLOCK_REALTIME

--- a/Makefile.am
+++ b/Makefile.am
@@ -84,7 +84,7 @@ libarchive_libarchive_a_SOURCES+=						\
 	libarchive/filter_fork_windows.c
 endif
 
-libarchive_libarchive_a_CFLAGS=-I $(top_builddir)/libarchive
+libarchive_libarchive_a_CPPFLAGS=-I $(top_builddir)/libarchive
 
 #
 # Tarsnap internal library code
@@ -168,7 +168,7 @@ lib_libtarsnap_a_SOURCES=					\
 		libcperciva/util/warnp.c			\
 		cpusupport-config.h
 
-lib_libtarsnap_a_CFLAGS=				\
+lib_libtarsnap_a_CPPFLAGS=				\
 		-I${top_srcdir}/tar			\
 		-I$(top_srcdir)/libarchive		\
 		-I${top_srcdir}/lib/crypto		\
@@ -201,16 +201,16 @@ CLEANFILES+=	cpusupport-config.h cpusupport-config.h.tmp
 lib_libtarsnap_aesni_a_SOURCES=				\
 		libcperciva/crypto/crypto_aes_aesni.c	\
 		cpusupport-config.h
-lib_libtarsnap_aesni_a_CFLAGS=	$(lib_libtarsnap_a_CFLAGS)	\
-	`. ./cpusupport-config.h; echo $${CFLAGS_X86_AESNI}`
+lib_libtarsnap_aesni_a_CPPFLAGS=$(lib_libtarsnap_a_CPPFLAGS)
+lib_libtarsnap_aesni_a_CFLAGS=`. ./cpusupport-config.h; echo $${CFLAGS_X86_AESNI}`
 
 LIBTARSNAP_A+=	lib/libtarsnap_aesni.a
 
 lib_libtarsnap_sse2_a_SOURCES=				\
 		lib/crypto/crypto_scrypt_smix_sse2.c	\
 		cpusupport-config.h
-lib_libtarsnap_sse2_a_CFLAGS=	$(lib_libtarsnap_a_CFLAGS)	\
-	`. ./cpusupport-config.h; echo $${CFLAGS_X86_SSE2}`
+lib_libtarsnap_sse2_a_CPPFLAGS=$(lib_libtarsnap_a_CPPFLAGS)
+lib_libtarsnap_sse2_a_CFLAGS=`. ./cpusupport-config.h; echo $${CFLAGS_X86_SSE2}`
 
 LIBTARSNAP_A+=	lib/libtarsnap_sse2.a
 
@@ -281,7 +281,7 @@ tarsnap_DEPENDENCIES = libarchive/libarchive.a		\
 		$(LIBTARSNAP_A)
 
 tarsnap_LDADD= -lcrypto libarchive/libarchive.a $(LIBTARSNAP_A)
-tarsnap_CFLAGS=						\
+tarsnap_CPPFLAGS=					\
 		-I$(top_srcdir)/libarchive		\
 		-DLIBARCHIVE_STATIC			\
 		-I$(top_srcdir)/tar			\
@@ -314,7 +314,7 @@ tarsnap_keygen_SOURCES=	keygen/keygen.c			\
 		keygen/keygen_network.c
 
 tarsnap_keygen_LDADD= -lcrypto $(LIBTARSNAP_A)
-tarsnap_keygen_CFLAGS=					\
+tarsnap_keygen_CPPFLAGS=				\
 		-I${top_srcdir}/libarchive		\
 		-I$(top_srcdir)/tar			\
 		-I$(top_srcdir)/keygen			\
@@ -341,7 +341,7 @@ tarsnap_keyregen_SOURCES=	keyregen/keyregen.c	\
 		keygen/keygen_network.c
 
 tarsnap_keyregen_LDADD= -lcrypto $(LIBTARSNAP_A)
-tarsnap_keyregen_CFLAGS=					\
+tarsnap_keyregen_CPPFLAGS=				\
 		-I${top_srcdir}/libarchive		\
 		-I$(top_srcdir)/tar			\
 		-I$(top_srcdir)/keygen			\
@@ -380,7 +380,7 @@ tarsnap_recrypt_SOURCES=	recrypt/recrypt.c	\
 		tar/storage/storage_transaction.c
 
 tarsnap_recrypt_LDADD= -lcrypto $(LIBTARSNAP_A)
-tarsnap_recrypt_CFLAGS=						\
+tarsnap_recrypt_CPPFLAGS=				\
 		-I$(top_srcdir)/tar			\
 		-I$(top_srcdir)/libarchive		\
 		-I$(top_srcdir)/tar/chunks		\
@@ -407,7 +407,7 @@ tarsnap_recrypt_dist_man_MANS=	recrypt/tarsnap-recrypt.1
 tarsnap_keymgmt_SOURCES= 	keymgmt/keymgmt.c
 
 tarsnap_keymgmt_LDADD= -lcrypto $(LIBTARSNAP_A)
-tarsnap_keymgmt_CFLAGS=					\
+tarsnap_keymgmt_CPPFLAGS=				\
 		-I$(top_srcdir)/tar			\
 		-I${top_srcdir}/libarchive		\
 		-I${top_srcdir}/lib/crypto		\


### PR DESCRIPTION
By default, the MacPorts `port` command runs configure scripts with `CPPFLAGS=-I/opt/local/include`, to pick up headers from MacPorts-installed libraries in /opt/local.  This was causing Tarsnap to build against /opt/local/include/archive.h instead of libarchive/archive.h, causing warnings such as

    tar/glue/archive_multitape.c:208:18: warning: implicit declaration of function 'archive_read_get_entryleft' is invalid in C99 [-Wimplicit-function-declaration]

The cause is that `$(CPPFLAGS)` precedes `$(<module>_CFLAGS)` in the argument list passed to `$(CC)`.  Fix by moving preprocessor options to `$(<module>_CPPFLAGS)` so they will precede `$(CPPFLAGS)`.

Also make some tiny fixes to C preprocessor flags, and clean up the output of `git status`.