### PR TITLE
"echo -n" is not portable; use printf

### DIFF
--- a/release-tools/mktarball.sh
+++ b/release-tools/mktarball.sh
@@ -20,7 +20,7 @@ done
 
 # Generate autotools files
 ( cd ${DESTDIR}
-echo -n ${VERSION} > tar-version
+printf ${VERSION} > tar-version
 autoreconf -i
 rm .autom4te.cfg Makefile.am aclocal.m4 actarsnap.m4 configure.ac tar-version tsserver )
 


### PR DESCRIPTION
    It is not possible to use echo portably across all POSIX systems unless
    both -n (as the first argument) and escape sequences are omitted.

http://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html