### PR TITLE
style: "/* Unused. */" -> "/* UNUSED */"

### DIFF
--- a/tar/ccache/ccache_read.c
+++ b/tar/ccache/ccache_read.c
@@ -138,8 +138,8 @@ callback_read_data(void * cookie, uint8_t * s, size_t slen, void * rec)
 	struct ccache_read_internal * R = cookie;
 	struct ccache_record * ccr = rec;
 
-	(void)s;	/* Unused. */
-	(void)slen;	/* Unused. */
+	(void)s;	/* UNUSED */
+	(void)slen;	/* UNUSED */
 
 	/* Read chunk headers, if present. */
 	if (ccr->nch) {
@@ -163,9 +163,9 @@ callback_free(void * cookie, uint8_t * s, size_t slen, void * rec)
 {
 	struct ccache_record * ccr = rec;
 
-	(void)cookie;	/* Unused. */
-	(void)s;	/* Unused. */
-	(void)slen;	/* Unused. */
+	(void)cookie;	/* UNUSED */
+	(void)s;	/* UNUSED */
+	(void)slen;	/* UNUSED */
 
 	/* Free chunkheader records, if they weren't mmapped. */
 	if (ccr->nchalloc)

--- a/tar/chunks/chunks_directory.c
+++ b/tar/chunks/chunks_directory.c
@@ -83,7 +83,7 @@ callback_free(void * rec, void * cookie)
 {
 	struct chunkdata * ch = rec;
 
-	(void)cookie; 	/* Unused. */
+	(void)cookie;	/* UNUSED */
 
 	if (ch->zlen_flags & CHDATA_MALLOC)
 		free(rec);


### PR DESCRIPTION
The latter form seems to be preferred, especially in libarchive code:

    td@gin: ~/src/tarsnap (style-unused)
    $ git grep "/\* UNUSED \*/" | wc -l
    114

(test run before this commit)