### PR TITLE
build: remove -Wno-unused-function

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,8 +2,6 @@
 
 AUTOMAKE_OPTIONS= foreign subdir-objects
 
-CFLAGS += -Wno-unused-function
-
 #
 # What to build and install
 #


### PR DESCRIPTION
This was added in 02b65c (2015-09-23) because ELASTICARRAY_DECL defined static
inline functions which were not necessarily used in the .c file that called
ELASTICARRAY_DECL.  However, that problem was fixed in 58567f (2016-01-17).