### PR TITLE
Avoid concatenating multiple xattr read errors

### DIFF
--- a/tar/write.c
+++ b/tar/write.c
@@ -897,9 +897,11 @@ write_hierarchy(struct bsdtar *bsdtar, struct archive *a, const char *path)
 		 * makes this more complex than it might sound. */
 		r = archive_read_disk_entry_from_file(bsdtar->diskreader,
 		    entry, -1, st);
-		if (r != ARCHIVE_OK)
+		if (r != ARCHIVE_OK) {
 			bsdtar_warnc(bsdtar, archive_errno(bsdtar->diskreader),
 			    "%s", archive_error_string(bsdtar->diskreader));
+			archive_clear_error(bsdtar->diskreader);
+		}
 		if (r < ARCHIVE_WARN)
 			continue;
 


### PR DESCRIPTION
This arose from running Tarsnap inside a jail:
    http://mail.tarsnap.com/tarsnap-users/msg01206.html

This patch doesn't address the root problem (FreeBSD not exposing xattr inside
a jail and/or Tarsnap not detecting it being in a jail and/or the user not
being able to specify a --no-xattr option (which was added to libarchive a few
days ago)).  But at least the warning messages no longer look ridiculous.