### PR TITLE
Clarify comments about keyfile skipping 8 bytes

### DIFF
--- a/lib/keyfile/keyfile.c
+++ b/lib/keyfile/keyfile.c
@@ -73,10 +73,10 @@ read_raw(const uint8_t * keybuf, size_t keylen, uint64_t * machinenum,
 		goto err0;
 	}
 
-	/* Parse machine number. */
+	/* Parse machine number from the first 8 bytes. */
 	*machinenum = be64dec(keybuf);
 
-	/* Parse keys. */
+	/* Parse keys from the remaining buffer. */
 	if (crypto_keys_import(&keybuf[8], keylen - 8, keys))
 		goto err0;
 


### PR DESCRIPTION
Obvious to some people, perhaps, but it took me a while to realize that

    &keybuf[8], keylen - 8

in read_raw() was not a copy&paste error from read_plaintext(), but was in
fact the machine number.