### PR TITLE
backport minor fixes from libarchive archive_entry_xattr_add_entry

### DIFF
--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -1709,12 +1709,10 @@ archive_entry_xattr_add_entry(struct archive_entry *entry,
 		;
 
 	if ((xp = (struct ae_xattr *)malloc(sizeof(struct ae_xattr))) == NULL)
-		/* XXX Error XXX */
-		return;
+		__archive_errx(1, "Out of memory");
 
 	if ((xp->name = strdup(name)) == NULL)
-		/* XXX Error XXX */
-		return;
+		__archive_errx(1, "Out of memory");
 
 	if ((xp->value = malloc(size)) != NULL) {
 		memcpy(xp->value, value, size);

--- a/libarchive/archive_entry.c
+++ b/libarchive/archive_entry.c
@@ -1705,9 +1705,6 @@ archive_entry_xattr_add_entry(struct archive_entry *entry,
 {
 	struct ae_xattr	*xp;
 
-	for (xp = entry->xattr_head; xp != NULL; xp = xp->next)
-		;
-
 	if ((xp = (struct ae_xattr *)malloc(sizeof(struct ae_xattr))) == NULL)
 		__archive_errx(1, "Out of memory");
 


### PR DESCRIPTION
This was accepted to libarchive upstream:
https://github.com/libarchive/libarchive/commit/8135eecf4530796050d0987e825cb6d2f99f6740
(the function is in a different file, but it's the same function)