### PR TITLE
build: add -D_POSIX_C_SOURCE=200809L

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -244,6 +244,7 @@ lib_libtarsnap_a_CPPFLAGS=				\
 		-I$(top_srcdir)/libcperciva/network	\
 		-I$(top_srcdir)/libcperciva/util	\
 		-DCPUSUPPORT_CONFIG_FILE=\"cpusupport-config.h\" \
+		-D_POSIX_C_SOURCE=200809L		\
 		-DPOSIXFAIL_MSG_NOSIGNAL \
 		-DPOSIXFAIL_CLOCK_REALTIME
 


### PR DESCRIPTION
Without this, clang-3.8 with -std=c99 on Ubuntu 16.04 fails to find SSIZE_MAX
in limits.h.  This is because SSIZE_MAX is in .../bits/posix1_lim.h, and
/usr/include/limits.h contains:

    #ifdef  __USE_POSIX
    /* POSIX adds things to <limits.h>.  */
    # include <bits/posix1_lim.h>
    #endif

and in "\__STRICT_ANSI__" mode (implied by -std=c99, amongst other things),
__USE_POSIX is only defined if we've defined _POSIX_C_SOURCE or _XOPEN_SOURCE.