### PR TITLE
Require that a --configfile exists

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 - tarsnap now accepts an --initialize-cachedir command, which is intended for
   the GUI and is not needed for command-line usage.
 - tarsnap now applies --humanize-numbers to the SIGINFO "progress" output.
+- tarsnap now gives a warning for --configfile /nosuchfile.
 
 
 Tarsnap Releases

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -1237,10 +1237,20 @@ configfile(struct bsdtar *bsdtar, const char *fname, int fromcmdline)
 	bsdtar->option_no_config_include_set =
 	    bsdtar->option_no_config_include;
 
-	/* If the file doesn't exist, do nothing. */
 	if (stat(fname, &sb)) {
-		if (errno == ENOENT)
-			return;
+		/* Missing file. */
+		if (errno == ENOENT) {
+			if (fromcmdline) {
+				bsdtar_errc(bsdtar, 1, errno,
+				    "Cannot read config file: %s", fname);
+			} else {
+				/*
+				 * If the file wasn't specified on the
+				 * command-line, do nothing.
+				 */
+				return;
+			}
+		}
 
 		/*
 		 * Something bad happened.  Note that this could occur if

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -106,7 +106,8 @@ time_t get_date(time_t, const char *);
 static struct bsdtar	*bsdtar_init(void);
 static void		 bsdtar_atexit(void);
 
-static void		 configfile(struct bsdtar *, const char *fname);
+static void		 configfile(struct bsdtar *, const char *fname,
+			     int fromcmdline);
 static int		 configfile_helper(struct bsdtar *bsdtar,
 			     const char *line);
 static void		 dooption(struct bsdtar *, const char *,
@@ -779,7 +780,7 @@ main(int argc, char **argv)
 
 	/* Process config files passed on the command line. */
 	for (i = 0; i < bsdtar->nconfigfiles; i++)
-		configfile(bsdtar, bsdtar->configfiles[i]);
+		configfile(bsdtar, bsdtar->configfiles[i], 1);
 
 	/* If we do not have --no-default-config, process default configs. */
 	if (bsdtar->option_no_default_config == 0) {
@@ -789,7 +790,7 @@ main(int argc, char **argv)
 			    bsdtar->homedir) == -1)
 				bsdtar_errc(bsdtar, 1, errno, "No memory");
 
-			configfile(bsdtar, bsdtar->conffile);
+			configfile(bsdtar, bsdtar->conffile, 0);
 
 			/* Free string allocated by asprintf. */
 			free(bsdtar->conffile);
@@ -797,7 +798,7 @@ main(int argc, char **argv)
 		}
 
 		/* Process options from system-wide tarsnap.conf. */
-		configfile(bsdtar, ETC_TARSNAP_CONF);
+		configfile(bsdtar, ETC_TARSNAP_CONF, 0);
 	}
 
 	/* Continue with more sanity-checking. */
@@ -1222,7 +1223,7 @@ long_help(struct bsdtar *bsdtar)
 
 /* Process options from the specified file, if it exists. */
 static void
-configfile(struct bsdtar *bsdtar, const char *fname)
+configfile(struct bsdtar *bsdtar, const char *fname, int fromcmdline)
 {
 	struct stat sb;
 


### PR DESCRIPTION
We (continue to) silently ignore a non-existent "default" config file that is
not explicitly passed via --configfile.