### PR TITLE
Update DEBIAN.md

### DIFF
--- a/pkg/DEBIAN.md
+++ b/pkg/DEBIAN.md
@@ -22,6 +22,9 @@ To use the official Tarsnap Debian source packages, set up:
         sudo apt-key add tarsnap-signing-key-2016.asc
         gpg --no-default-keyring --keyring ~/.gnupg/trustedkeys.gpg \
           --import tarsnap-signing-key-2016.asc
+        sudo apt-key adv --keyserver keyserver.ubuntu.com \
+          --recv-keys 1397BC53640DB551
+
 
    (adjust the filename of the Tarsnap signing key in 2017 or later years)
 


### PR DESCRIPTION
This prevents the error:

    W: There is no public key available for the following key IDs:
    1397BC53640DB551

This was taken from http://askubuntu.com/questions/766883/there-is-no-public-key-available-for-the-following-key-ids-1397bc53640db551. I really understand next to nothing about it, so I have no idea of the security implications. 

Or maybe `gpg --no-default-keyring --keyring ~/.gnupg/trustedkeys.gpg --import tarsnap-signing-key-2016.asc` needs to be done using sudo? No idea. The keyserver command worked for me though.