### PR TITLE
pkg: add newline to Debian .dsc file

### DIFF
--- a/release-tools/mkdebsource.sh
+++ b/release-tools/mkdebsource.sh
@@ -56,6 +56,9 @@ cp -r pkg/debian .
 # Debianize: create tarsnap_*.debian.tar.gz and tarsnap_*.dsc
 debuild -S -us -uc
 
+# Add missing newline to bottom of tarsnap_*.dsc
+printf "\n" >> ${BUILDDIR}/tarsnap_$VERSION-$REVISION.dsc
+
 # Inform the user of the package location
 echo "\nDebian source package created in:"
 echo "    ${BUILDDIR}"


### PR DESCRIPTION
A strict interpretation of the Debian standards requires this newline.