### PR TITLE
pkg: explicitly use gz compression

### DIFF
--- a/pkg/debian/source/options
+++ b/pkg/debian/source/options
@@ -1,0 +1,2 @@
+compression = "gzip"
+compression-level = 9


### PR DESCRIPTION
Otherwise, different versions of debuild can produce .debian.tar.* files which use different compression formats (i.e. Ubuntu now uses .xz by default, whereas Debian still uses .gz).  This could unnecessarily muddy attempts at reproducibility.