### PR TITLE
build: add --with-conf-no-sample for tarsnap.conf

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -496,8 +496,16 @@ tarsnap_keymgmt_CPPFLAGS=				\
 
 tarsnap_keymgmt_man_MANS=	keymgmt/tarsnap-keymgmt.1
 
-#  Tarsnap sample configuration file
+#  Tarsnap configuration file
+if INSTALL_CONF_NO_SAMPLE
+tar/tarsnap.conf: tar/tarsnap.conf.sample
+	cp $< $@
+
+sysconf_DATA	=	tar/tarsnap.conf
+CLEANFILES	+=	tar/tarsnap.conf
+else
 sysconf_DATA	=	tar/tarsnap.conf.sample
+endif
 
 # Use the right version of the man pages depending on whether we have mdoc
 # macros available on this system.

--- a/configure.ac
+++ b/configure.ac
@@ -444,6 +444,14 @@ AC_SYS_LARGEFILE
 AC_CHECK_DECLS([optarg])
 AC_CHECK_DECLS([optind])
 
+# Strip the .sample from tarsnap.conf.sample (if requested by the user).
+AC_ARG_WITH([conf-no-sample],
+    AS_HELP_STRING([--with-conf-no-sample],
+        [Install tarsnap.conf without the .sample suffix.]),
+    [], [with_conf_no_sample=no])
+AM_CONDITIONAL([INSTALL_CONF_NO_SAMPLE],
+    [test "x$with_conf_no_sample" != "xno"])
+
 # install bash completion
 AC_ARG_WITH([bash-completion-dir],
     AS_HELP_STRING([--with-bash-completion-dir@<:@=DIRNAME@:>@],


### PR DESCRIPTION
This will install "tarsnap.conf" instead of "tarsnap.conf.sample". Not recommended for end-users, as it would be easy to accidentally destroy one's tarsnap config.  However, this could be useful for a package manager (like apt-get) which has built-in handling for not overwriting user-edited config files.