### PR TITLE
Fix humansize_parse("")

### DIFF
--- a/libcperciva/util/humansize.c
+++ b/libcperciva/util/humansize.c
@@ -67,7 +67,7 @@ humansize_parse(const char * s, uint64_t * size)
 	int state = 0;
 	uint64_t multiplier = 1;
 
-	while (*s != '\0') {
+	do {
 		switch (state) {
 		case -1:
 			/* Error state. */
@@ -152,7 +152,7 @@ humansize_parse(const char * s, uint64_t * size)
 
 		/* Move on to the next character. */
 		s++;
-	}
+	} while (*s != '\0');
 
 	/* Multiply by multiplier. */
 	if (*size > UINT64_MAX / multiplier)


### PR DESCRIPTION
An empty string is not a valid number of bytes; we must have at least
one digit.

Reported by:	Coverity Scan