### PR TITLE
key(*)gen, recrypt: (void)argv after usage.

### DIFF
--- a/keygen/keygen.c
+++ b/keygen/keygen.c
@@ -126,6 +126,7 @@ main(int argc, char **argv)
 	/* We should have processed all the arguments. */
 	if (argc != 0)
 		usage();
+	(void)argv; /* argv is not used beyond this point. */
 
 	/* We must have a user name, machine name, and key file specified. */
 	if ((C.user == NULL) || (C.name == NULL) || (keyfilename == NULL))

--- a/keyregen/keyregen.c
+++ b/keyregen/keyregen.c
@@ -136,6 +136,7 @@ main(int argc, char **argv)
 	/* We should have processed all the arguments. */
 	if (argc != 0)
 		usage();
+	(void)argv; /* argv is not used beyond this point. */
 
 	/*
 	 * We must have a user name, machine name, key file, and old key

--- a/recrypt/recrypt.c
+++ b/recrypt/recrypt.c
@@ -432,6 +432,7 @@ main(int argc, char **argv)
 	/* We should have processed all the arguments. */
 	if (argc != 0)
 		usage();
+	(void)argv; /* argv is not used beyond this point. */
 
 	/* Make sure we have the necessary options. */
 	if ((ocachedir == NULL) || (ncachedir == NULL) ||


### PR DESCRIPTION
This silences warnings in clang's scan-build tool.