### PR TITLE
take archive names from stdin when the -f option is '-'

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,8 @@
 - tarsnap now accepts --iso-dates, which prints file and directory dates as
   yyyy-mm-dd hh:mm:ss in "list archive" mode.  This can be cancelled with
   --no-iso-dates.
+- tarsnap now reads archive names from stdin when you specify -f - while in the
+  -d or --print-stats modes.
 
 
 Tarsnap Releases

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -109,7 +109,7 @@ static void		 bsdtar_atexit(void);
 static void		 configfile(struct bsdtar *, const char *fname,
 			     int fromcmdline);
 static int		 configfile_helper(struct bsdtar *bsdtar,
-			     const char *line);
+			     const char *line, void *context);
 static void		 dooption(struct bsdtar *, const char *,
 			     const char *, int);
 static int		 load_keys(struct bsdtar *, const char *path);
@@ -1277,12 +1277,12 @@ configfile(struct bsdtar *bsdtar, const char *fname, int fromcmdline)
 	}
 
 	/* Process the file. */
-	process_lines(bsdtar, fname, configfile_helper, 0);
+	process_lines(bsdtar, fname, configfile_helper, 0, 0);
 }
 
 /* Process a line of configuration file. */
 static int
-configfile_helper(struct bsdtar *bsdtar, const char *line)
+configfile_helper(struct bsdtar *bsdtar, const char *line, void *context)
 {
 	char * conf_arg;
 	size_t optlen;
@@ -1466,7 +1466,7 @@ dooption(struct bsdtar *bsdtar, const char * conf_opt,
 		if (conf_arg == NULL)
 			goto needarg;
 
-		if (exclude(bsdtar, conf_arg))
+		if (exclude(bsdtar, conf_arg, 0))
 			bsdtar_errc(bsdtar, 1, 0,
 			    "Couldn't exclude %s", conf_arg);
 	} else if (strcmp(conf_opt, "force-resources") == 0) {
@@ -1487,7 +1487,7 @@ dooption(struct bsdtar *bsdtar, const char * conf_opt,
 		if (conf_arg == NULL)
 			goto needarg;
 
-		if (include(bsdtar, conf_arg))
+		if (include(bsdtar, conf_arg, 0))
 			bsdtar_errc(bsdtar, 1, 0,
 			    "Failed to add %s to inclusion list", conf_arg);
 	} else if (strcmp(conf_opt, "insane-filesystems") == 0) {

--- a/tar/bsdtar.h
+++ b/tar/bsdtar.h
@@ -263,14 +263,14 @@ void	bsdtar_warnc(struct bsdtar *, int _code, const char *fmt, ...);
 void	cleanup_exclusions(struct bsdtar *);
 void	do_chdir(struct bsdtar *);
 int	edit_pathname(struct bsdtar *, struct archive_entry *);
-int	exclude(struct bsdtar *, const char *pattern);
+int	exclude(struct bsdtar *, const char *pattern, void *context);
 int	exclude_from_file(struct bsdtar *, const char *pathname);
 int	excluded(struct bsdtar *, const char *pathname);
-int	include(struct bsdtar *, const char *pattern);
+int	include(struct bsdtar *, const char *pattern, void *context);
 int	include_from_file(struct bsdtar *, const char *pathname);
 int	pathcmp(const char *a, const char *b);
 int	process_lines(struct bsdtar *bsdtar, const char *pathname,
-	    int (*process)(struct bsdtar *, const char *), int null);
+	    int (*process)(struct bsdtar *, const char *, void *), int null, void *context);
 void	safe_fprintf(FILE *, const char *fmt, ...);
 void	set_chdir(struct bsdtar *, const char *newdir);
 void	siginfo_init(struct bsdtar *);

--- a/tar/glue/tape.c
+++ b/tar/glue/tape.c
@@ -37,7 +37,7 @@ tarsnap_mode_d(struct bsdtar *bsdtar)
 
 	/* Delete archives. */
 	for (i = 0; i < bsdtar->ntapes; i++) {
-		if (bsdtar->verbose && (bsdtar->ntapes > 1))
+		if (bsdtar->verbose)
 			fprintf(stderr, "Deleting archive \"%s\"\n",
 			    bsdtar->tapenames[i]);
 		if (strcmp(bsdtar->tapenames[i], "-") == 0)

--- a/tar/glue/tape.c
+++ b/tar/glue/tape.c
@@ -14,6 +14,17 @@
 /*
  * Delete a tape.
  */
+int
+tarsnap_mode_d_callback(struct bsdtar *bsdtar, const char *archive,
+                        void *context) {
+	return deletetape((TAPE_D *)context, bsdtar->machinenum, bsdtar->cachedir,
+	                  archive, bsdtar->option_print_stats, 1,
+	                  bsdtar->option_csv_filename);
+}
+
+/*
+ * Delete all listed tapes.
+ */
 void
 tarsnap_mode_d(struct bsdtar *bsdtar)
 {
@@ -29,18 +40,22 @@ tarsnap_mode_d(struct bsdtar *bsdtar)
 		if (bsdtar->verbose && (bsdtar->ntapes > 1))
 			fprintf(stderr, "Deleting archive \"%s\"\n",
 			    bsdtar->tapenames[i]);
-		switch (deletetape(d, bsdtar->machinenum, bsdtar->cachedir,
-		    bsdtar->tapenames[i], bsdtar->option_print_stats,
-		    bsdtar->ntapes > 1 ? 1 : 0, bsdtar->option_csv_filename)) {
-		case 0:
-			break;
-		case 1:
-			if (bsdtar->option_keep_going)
+		if (strcmp(bsdtar->tapenames[i], "-") == 0)
+			process_lines(bsdtar, bsdtar->tapenames[i],
+			              tarsnap_mode_d_callback, bsdtar->option_null, (void*)d);
+		else
+			switch (deletetape(d, bsdtar->machinenum, bsdtar->cachedir,
+			    bsdtar->tapenames[i], bsdtar->option_print_stats,
+			    bsdtar->ntapes > 1 ? 1 : 0, bsdtar->option_csv_filename)) {
+			case 0:
 				break;
-			/* FALLTHROUGH */
-		default:
-			goto err2;
-		}
+			case 1:
+				if (bsdtar->option_keep_going)
+					break;
+				/* FALLTHROUGH */
+			default:
+				goto err2;
+			}
 	}
 
 	/* We've finished deleting archives. */
@@ -109,6 +124,17 @@ err1:
 }
 
 /*
+ * Print statistics relating to an archive.
+ */
+
+int
+tarsnap_mode_print_stats_callback(struct bsdtar *bsdtar, const char *archive, void *context)
+{
+	return statstape_print((TAPE_S*)context, archive,
+	                       bsdtar->option_csv_filename);
+}
+
+/*
  * Print statistics relating to an archive or set of archives.
  */
 void
@@ -136,17 +162,22 @@ tarsnap_mode_print_stats(struct bsdtar *bsdtar)
 	} else {
 		/* User wants statistics about specific archive(s). */
 		for (i = 0; i < bsdtar->ntapes; i++) {
-			switch (statstape_print(d, bsdtar->tapenames[i],
-			    bsdtar->option_csv_filename)) {
-			case 0:
-				break;
-			case 1:
-				if (bsdtar->option_keep_going)
+			if (strcmp(bsdtar->tapenames[i], "-") == 0)
+				process_lines(bsdtar, bsdtar->tapenames[i],
+				              tarsnap_mode_print_stats_callback, bsdtar->option_null,
+				              (void*)d);
+			else
+				switch (statstape_print(d, bsdtar->tapenames[i],
+				    bsdtar->option_csv_filename)) {
+				case 0:
 					break;
-				/* FALLTHROUGH */
-			default:
-				goto err2;
-			}
+				case 1:
+					if (bsdtar->option_keep_going)
+						break;
+					/* FALLTHROUGH */
+				default:
+					goto err2;
+				}
 		}
 	}
 

--- a/tar/matching.c
+++ b/tar/matching.c
@@ -78,7 +78,7 @@ static int	pathmatch(const char *p, const char *s);
  */
 
 int
-exclude(struct bsdtar *bsdtar, const char *pattern)
+exclude(struct bsdtar *bsdtar, const char *pattern, void *context)
 {
 	struct matching *matching;
 
@@ -94,11 +94,11 @@ int
 exclude_from_file(struct bsdtar *bsdtar, const char *pathname)
 {
 	return (process_lines(bsdtar, pathname, &exclude,
-	    bsdtar->option_null));
+	    bsdtar->option_null, 0));
 }
 
 int
-include(struct bsdtar *bsdtar, const char *pattern)
+include(struct bsdtar *bsdtar, const char *pattern, void *context)
 {
 	struct matching *matching;
 
@@ -115,7 +115,7 @@ int
 include_from_file(struct bsdtar *bsdtar, const char *pathname)
 {
 	return (process_lines(bsdtar, pathname, &include,
-	    bsdtar->option_null));
+	    bsdtar->option_null, 0));
 }
 
 static void

--- a/tar/read.c
+++ b/tar/read.c
@@ -124,7 +124,7 @@ read_archive(struct bsdtar *bsdtar, char mode)
 	int			  r;
 
 	while (*bsdtar->argv) {
-		include(bsdtar, *bsdtar->argv);
+		include(bsdtar, *bsdtar->argv, 0);
 		bsdtar->argv++;
 	}
 

--- a/tar/tarsnap.1-man.in
+++ b/tar/tarsnap.1-man.in
@@ -343,7 +343,9 @@ In the print-stats and d modes,
 \fB\-f\fP \fIarchive-name\fP
 can be specified multiple times, in which case the operation
 (printing statistics, or deletion) will be performed for each
-of the specified archives.
+of the specified archives;
+\fIarchive-name\fP
+may also be -, in which case archive names will be read from stdin.
 .PP
 Note that each archive created must have a different name; consequently
 many users find it useful to include timestamps in archive names when

--- a/tar/tarsnap.1-mdoc.in
+++ b/tar/tarsnap.1-mdoc.in
@@ -328,7 +328,9 @@ In the print-stats and d modes,
 .Fl f Ar archive-name
 can be specified multiple times, in which case the operation
 (printing statistics, or deletion) will be performed for each
-of the specified archives.
+of the specified archive.s;
+.Ar archive-name
+may also be -, in which case archive names will be read from stdin.
 .Pp
 Note that each archive created must have a different name; consequently
 many users find it useful to include timestamps in archive names when

--- a/tar/util.c
+++ b/tar/util.c
@@ -286,7 +286,8 @@ yes(const char *fmt, ...)
  */
 int
 process_lines(struct bsdtar *bsdtar, const char *pathname,
-    int (*process)(struct bsdtar *, const char *), int null)
+    int (*process)(struct bsdtar *, const char *, void *), int null,
+    void *context)
 {
 	FILE *f;
 	char *buff, *buff_end, *line_start, *line_end, *p;
@@ -346,7 +347,7 @@ process_lines(struct bsdtar *bsdtar, const char *pathname,
 				if (*line_end == '\015')
 					lastcharwasr = 1;
 				*line_end = '\0';
-				if ((*process)(bsdtar, line_start) != 0)
+				if ((*process)(bsdtar, line_start, context) != 0)
 					ret = -1;
 				line_start = line_end + 1;
 				line_end = line_start;
@@ -383,7 +384,7 @@ process_lines(struct bsdtar *bsdtar, const char *pathname,
 	/* At end-of-file, handle the final line. */
 	if (line_end > line_start) {
 		*line_end = '\0';
-		if ((*process)(bsdtar, line_start) != 0)
+		if ((*process)(bsdtar, line_start, context) != 0)
 			ret = -1;
 	}
 	free(buff);

--- a/tar/write.c
+++ b/tar/write.c
@@ -112,7 +112,7 @@ static int		 append_archive_tarsnap(struct bsdtar *,
 static void		 archive_names_from_file(struct bsdtar *bsdtar,
 			     struct archive *a);
 static int		 archive_names_from_file_helper(struct bsdtar *bsdtar,
-			     const char *line);
+			     const char *line, void *context);
 static int		 copy_file_data(struct bsdtar *bsdtar,
 			     struct archive *a, struct archive *ina);
 static int		 getdevino(struct archive *, const char *, dev_t *,
@@ -498,7 +498,7 @@ archive_names_from_file(struct bsdtar *bsdtar, struct archive *a)
 
 	bsdtar->next_line_is_dir = 0;
 	process_lines(bsdtar, bsdtar->names_from_file,
-	    archive_names_from_file_helper, bsdtar->option_null);
+	    archive_names_from_file_helper, bsdtar->option_null, 0);
 	if (bsdtar->next_line_is_dir)
 		bsdtar_errc(bsdtar, 1, errno,
 		    "Unexpected end of filename list; "
@@ -506,7 +506,8 @@ archive_names_from_file(struct bsdtar *bsdtar, struct archive *a)
 }
 
 static int
-archive_names_from_file_helper(struct bsdtar *bsdtar, const char *line)
+archive_names_from_file_helper(struct bsdtar *bsdtar, const char *line,
+                               void *context)
 {
 	if (bsdtar->next_line_is_dir) {
 		if (*line != '\0')


### PR DESCRIPTION
I had to delete a number of daily backups, and my mind rebelled at the thought of writing a command to convert a nice list of archive names into the required command-line options. I just couldn't do it; it was too dumb.

Instead I modified tarsnap so that it can read archive names from stdin. I've tested both -d and --print-stats; both work great. Of course, there might well be edge cases I haven't considered.

Enjoy