### PR TITLE
build: use -D_XOPEN_SOURCE=700

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -245,6 +245,7 @@ lib_libtarsnap_a_CPPFLAGS=				\
 		-I$(top_srcdir)/libcperciva/util	\
 		-DCPUSUPPORT_CONFIG_FILE=\"cpusupport-config.h\" \
 		-D_POSIX_C_SOURCE=200809L		\
+		-D_XOPEN_SOURCE=700			\
 		-DPOSIXFAIL_MSG_NOSIGNAL		\
 		-DPOSIXFAIL_CLOCK_REALTIME
 

--- a/lib/util/getfstype.c
+++ b/lib/util/getfstype.c
@@ -1,5 +1,6 @@
 /* We use non-POSIX functionality in this file. */
 #undef _POSIX_C_SOURCE
+#undef _XOPEN_SOURCE
 
 #include "bsdtar_platform.h"
 

--- a/lib/util/memlimit.c
+++ b/lib/util/memlimit.c
@@ -29,6 +29,7 @@
 
 /* We use non-POSIX functionality in this file. */
 #undef _POSIX_C_SOURCE
+#undef _XOPEN_SOURCE
 
 #include "bsdtar_platform.h"
 


### PR DESCRIPTION
This is required to use lockf, as it is an [XSI] extension:
http://pubs.opengroup.org/onlinepubs/9699919799/functions/lockf.html

[Currently, we use GNU_SOURCE, which implicitly enables lockf.  This commit
reduces that dependency.]