### PR TITLE
Backport archive_clear_error() fix

### DIFF
--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -165,6 +165,7 @@ archive_clear_error(struct archive *a)
 {
 	archive_string_empty(&a->error_string);
 	a->error = NULL;
+	a->archive_error_number = 0;
 }
 
 void


### PR DESCRIPTION
This comes from upstream, on 2010-02-25:
https://github.com/libarchive/libarchive/commit/d75d45bfa46cdd187e64c3332bbeead5b324e6a9

Tim Kientzel wrote:
> Set archive_error_number to zero here. I'm a little uneasy about this, as
> there are apparently libarchive uers that abuse archive_errno() and this
> change is likely to mask bugs in such software.
>
> SVN-Revision: 1989

I think we should backport this because:

- archive_read_support_compression_all() deliberately calls function-specific
  "enable compression" functions, then calls archive_clear_error().  The
  comment is:

        /* Note: We always return ARCHIVE_OK here, even if some of the
         * above return ARCHIVE_WARN.  The intent here is to enable
         * "as much as possible."  Clients who need specific
         * compression should enable those individually so they can
         * verify the level of support. */

- Without this patch, the archive will have no error string and
  ->errno = NULL; however, it can have a non-zero ->archive_errno_number.
  The function archive_errno() checks ->archive_errno_number rather than
  ->errno.
- In append_archive_filename(), we don't check archive_errno(ina) after calling
  archive_read_support_compression_all(); instead, we call
  archive_read_open_file(), append_archive(), and only *then* do we check
  archive_errno().  This can result in spurious errors like:
      tarsnap: Error reading archive bsdtar.ar: (Empty error message)