### PR TITLE
Add missing include assert.h

### DIFF
--- a/tar/multitape/multitape_metadata.c
+++ b/tar/multitape/multitape_metadata.c
@@ -2,6 +2,7 @@
 
 #include <sys/types.h>
 
+#include <assert.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Build fails on MacOS/LLVM/Clang with:

tar/multitape/multitape_metadata.c:72:2: warning: implicit declaration of function 'assert' is invalid in C99 [-Wimplicit-function-declaration]
assert((mdat->argc >= 0) && ((uintmax_t)mdat->argc <= UINT32_MAX));
gcc  -g -O2  -L/usr/local/opt/openssl/lib -o tarsnap-keymgmt keymgmt/tarsnap_keymgmt-keymgmt.o lib/libtarsnap.a lib/libtarsnap_aesni.a lib/libtarsnap_sse2.a -llzma -lbz2 -lcrypto -lz
Undefined symbols for architecture x86_64:
  "_assert", referenced from:
      _multitape_metadata_enc in tarsnap_recrypt-multitape_metadata.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)