### PR TITLE
Travis-CI: use stricter compiler flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,28 @@
 language: C
-sudo: required
+sudo: false
 dist: trusty
-script: make
+# We can't use strict flags in CFLAGS as a general environment
+# variable, because that messes up ./configure.  We also need to use
+# much more permissive "strict" checks for our version of libarchive.
+script:
+- make "CFLAGS=$CFLAGS $CFLAGS_LIBARCHIVE"
+      tar/tarsnap-bsdtar.o tar/tarsnap-getdate.o tar/tarsnap-subst.o
+      tar/tarsnap-tree.o tar/tarsnap-util.o tar/tarsnap-write.o
+      libarchive/libarchive.a
+  && make "CFLAGS=$CFLAGS $CFLAGS_STRICT"
+matrix:
+  include:
+    - compiler: gcc
+      env: CFLAGS="-std=c99 -O2 -Wall -Wextra -Werror"
+           CFLAGS_STRICT="-Wpedantic -pedantic-errors -Wno-clobbered"
+           CFLAGS_LIBARCHIVE="$CFLAGS_STRICT"
+    - compiler: clang
+      env: CFLAGS="-std=c99 -O2 -Wall -Wextra -Werror"
+           CFLAGS_STRICT="-Weverything -Werror -Wno-#warnings -Wno-pedantic -Wno-padded -Wno-format-nonliteral -Wno-disabled-macro-expansion -Wno-undef -Wno-documentation-unknown-command -Wno-missing-noreturn -Wno-unused-function"
+           CFLAGS_LIBARCHIVE="-Weverything -Werror -Wno-#warnings -Wno-pedantic -Wno-padded -Wno-format-nonliteral -Wno-disabled-macro-expansion -Wno-missing-noreturn -Wno-sign-conversion -Wno-undef -Wno-shorten-64-to-32 -Wno-shadow -Wno-conversion -Wno-unused-macros -Wno-class-varargs -Wno-unreachable-code -Wno-tautological-overlap-compare -Wno-float-equal -Wno-unreachable-code-break -Wno-unused-function"
+addons:
+  apt:
+    packages: libssl-dev zlib1g-dev e2fslibs-dev
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq libssl-dev zlib1g-dev e2fslibs-dev
   - autoreconf -i
   - ./configure


### PR DESCRIPTION
Our version of libarchive is a bit old, and requires a much more lax set of
compiler flags than the rest of the tarsnap code.

This commit also switches over to Travis-CI's container system.