### PR TITLE
Set key to NULL when discarding old values.

### DIFF
--- a/lib/crypto/crypto_keys_subr.c
+++ b/lib/crypto/crypto_keys_subr.c
@@ -180,6 +180,7 @@ crypto_keys_subr_import_RSA_priv(RSA ** key, const uint8_t * buf, size_t buflen)
 	/* Free any existing key. */
 	if (*key != NULL)
 		RSA_free(*key);
+	*key = NULL;
 
 	/* Create a new key. */
 	if ((*key = RSA_new()) == NULL) {
@@ -248,6 +249,7 @@ crypto_keys_subr_import_RSA_pub(RSA ** key, const uint8_t * buf, size_t buflen)
 	/* Free any existing key. */
 	if (*key != NULL)
 		RSA_free(*key);
+	*key = NULL;
 
 	/* Create a new key. */
 	if ((*key = RSA_new()) == NULL) {
@@ -298,6 +300,7 @@ crypto_keys_subr_import_HMAC(struct crypto_hmac_key ** key,
 		free((*key)->key);
 		free(*key);
 	}
+	*key = NULL;
 
 	/* Make sure the buffer is the right length. */
 	if (buflen != 32) {
@@ -458,6 +461,7 @@ crypto_keys_subr_generate_RSA(RSA ** priv, RSA ** pub)
 		RSA_free(*priv);
 	if (*pub != NULL)
 		RSA_free(*pub);
+	*priv = *pub = NULL;
 
 	if ((*priv = crypto_compat_RSA_generate_key()) == NULL) {
 		warn0("%s", ERR_error_string(ERR_get_error(), NULL));


### PR DESCRIPTION
In most cases we were about to immediately set the key to a new
value; but in crypto_keys_subr_import_HMAC we check the buffer
length before the malloc call.  As a result, reading a (corrupt)
tarsnap key file which has a value HMAC key followed by an HMAC
key with the same type but an invalid length resulted in the key
being freed in crypto_keys_subr_import_HMAC and then freed again
when keys were cleaned up during atexit handling.

Since the problem is triggered only by the handling of corrupt key
files and arises as a double free (or access to freed memory, but
the memory in question won't have been overwritten) moments before
we exit(1), this is pretty much harmless; but it is *technically*
a crash, and could have been worse if the code had been structured
differently.

Reported by:	GwanYeong Kim
Security:	Access to freed memory / double-free during error
		exit path.
Bug Bounty:	$100