### PR TITLE
Update Fedora spec file to 1.0.39

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -49,7 +49,7 @@ To build a Fedora package:
     sudo dnf install rpmdevtools
     sudo dnf builddep pkg/fedora/tarsnap.spec
     rpmdev-setuptree
-    cp .../tarsnap-autoconf-<version>.tgz ~/rpmbuild/SOURCES
+    spectool -g pkg/fedora/tarsnap.spec -C ~/rpmbuild/SOURCES
     rpmbuild -bb pkg/fedora/tarsnap.spec
 
 Then to install it:

--- a/pkg/fedora/tarsnap.spec
+++ b/pkg/fedora/tarsnap.spec
@@ -1,11 +1,11 @@
 Name:           tarsnap
-Version:        1.0.37
+Version:        1.0.39
 Release:        1%{?dist}
 Summary:        Secure, efficient online backup service
 
 License:        Proprietary
-URL:            http://www.tarsnap.com/
-Source0:        http://www.tarsnap.com/download/tarsnap-autoconf-%{version}.tgz
+URL:            https://www.tarsnap.com/
+Source0:        https://www.tarsnap.com/download/tarsnap-autoconf-%{version}.tgz
 
 BuildRequires:  gcc
 BuildRequires:  bzip2-devel
@@ -53,6 +53,10 @@ mv $RPM_BUILD_ROOT/%{_sysconfdir}/tarsnap.conf.sample \
 
 
 %changelog
+* Sun Sep  3 2017 David Sastre Medina <d.sastre.medina@gmail.com> 1.0.39-1
+- Upstream version 1.0.39
+- Switch to HTTPS URLs.
+
 * Mon Mar  7 2016 Graham Percival <gperciva@tarsnap.com> 1.0.37-1
 - Upstream version 1.0.37
 - Reinstate libattr dependency, and add lzma.


### PR DESCRIPTION
Update to latest Tarsnap release.
  
 - Update to latest Tarsnap release 1.0.39 (July 29, 2017)
 - Use HTTPS URLs in spec file
 - Update ChangeLog

Update Fedora installation instructions in README.md
    
Since `rpmdevtools` is listed in the documentation as part of the installation process, use `spectool` (part of `rpmdevtools`) to download the upstream tarball and place it in the (default) `~/rpmbuild/SOURCES` directory.
