### PR TITLE
build: fix OpenSSL paths for darwin

### DIFF
--- a/actarsnap.m4
+++ b/actarsnap.m4
@@ -63,6 +63,19 @@ case $target_os in
 esac
 ])# CHECK_SOLARIS_PATHS
 
+# CHECK_DARWIN_PATHS
+# -------------------
+AC_DEFUN([CHECK_DARWIN_PATHS],
+[AC_REQUIRE([AC_CANONICAL_TARGET])
+
+case $target_os in
+*darwin*)
+	CPPFLAGS="${CPPFLAGS} -I/usr/local/opt/openssl/include"
+	LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl/lib"
+	;;
+esac
+])# CHECK_DARWIN_PATHS
+
 # CHECK_MDOC_OR_MAN
 # -----------------
 # If 'nroff -mdoc' or 'mandoc -mdoc' returns with an exit status of 0, we will

--- a/configure.ac
+++ b/configure.ac
@@ -154,6 +154,9 @@ AC_CHECK_HEADERS([linux/magic.h])
 # be able to find it...
 CHECK_SOLARIS_PATHS
 
+# Ditto for Darwin.
+CHECK_DARWIN_PATHS
+
 # Check if we should use mdoc versions of the man pages or versions which
 # are uglier but more portable.
 CHECK_MDOC_OR_MAN


### PR DESCRIPTION
I noticed that `autoreconf -i` doesn't set the OpenSSL paths on OS X, causing
`./configure` to fail. After applying this patch, I was able to build Tarsnap
without problems.