### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ The official releases should build and install using autotools:
 
 See the [BUILDING](BUILDING) file for more details.
 
+Building on OSX 10.10+
+----------------------
+
+Currently tarsnap requires linking against OpenSSL, and to compile tarsnap it
+also needs to find the OpenSSL headers. On OSX 10.10+ the OpenSSL headers have
+been removed, but if you're using Homebrew you can install them via:
+
+```sh
+brew install openssl
+```
 
 Packaging notes
 ---------------


### PR DESCRIPTION
With regards to the OpenSSL libraries on macOS, I ran across a project in a similar situation as Tarsnap:

https://github.com/alexcrichton/git2-rs/blob/3d61c663bb36ae4475041a7061fe47c08e8c0527/README.md#building-on-osx-1010

This PR just copies their README.md section on OpenSSL.