### PR TITLE
Add major/minor headers in tar/util.c

### DIFF
--- a/tar/read.c
+++ b/tar/read.c
@@ -34,11 +34,6 @@ __FBSDID("$FreeBSD: src/usr.bin/tar/read.c,v 1.40 2008/08/21 06:41:14 kientzle E
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
-#ifdef MAJOR_IN_MKDEV
-#include <sys/mkdev.h>
-#elif defined(MAJOR_IN_SYSMACROS)
-#include <sys/sysmacros.h>
-#endif
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif

--- a/tar/util.c
+++ b/tar/util.c
@@ -37,6 +37,12 @@ __FBSDID("$FreeBSD: src/usr.bin/tar/util.c,v 1.23 2008/12/15 06:00:25 kientzle E
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>  /* Linux doesn't define mode_t, etc. in sys/stat.h. */
 #endif
+#ifdef MAJOR_IN_MKDEV
+#include <sys/mkdev.h>
+#else
+#ifdef MAJOR_IN_SYSMACROS
+#include <sys/sysmacros.h>
+#endif
 #include <ctype.h>
 #ifdef HAVE_ERRNO_H
 #include <errno.h>

--- a/tar/util.c
+++ b/tar/util.c
@@ -43,6 +43,7 @@ __FBSDID("$FreeBSD: src/usr.bin/tar/util.c,v 1.23 2008/12/15 06:00:25 kientzle E
 #ifdef MAJOR_IN_SYSMACROS
 #include <sys/sysmacros.h>
 #endif
+#endif
 #include <ctype.h>
 #ifdef HAVE_ERRNO_H
 #include <errno.h>

--- a/tar/util.c
+++ b/tar/util.c
@@ -39,10 +39,8 @@ __FBSDID("$FreeBSD: src/usr.bin/tar/util.c,v 1.23 2008/12/15 06:00:25 kientzle E
 #endif
 #ifdef MAJOR_IN_MKDEV
 #include <sys/mkdev.h>
-#else
-#ifdef MAJOR_IN_SYSMACROS
+#elif defined(MAJOR_IN_SYSMACROS)
 #include <sys/sysmacros.h>
-#endif
 #endif
 #include <ctype.h>
 #ifdef HAVE_ERRNO_H


### PR DESCRIPTION
Otherwise I get the following in Ubuntu 20.04.2 LTS.

```
/usr/bin/ld: tar/tarsnap-util.o: in function `list_item_verbose':
util.c:(.text+0x198b): undefined reference to `minor'
/usr/bin/ld: util.c:(.text+0x19a6): undefined reference to `major'
```
