### PR TITLE
Fix OpenSSL detection on Apple silicon

### DIFF
--- a/m4/check_darwin_paths.m4
+++ b/m4/check_darwin_paths.m4
@@ -5,8 +5,16 @@ AC_DEFUN([CHECK_DARWIN_PATHS],
 
 case $target_os in
 *darwin*)
-	CPPFLAGS="${CPPFLAGS} -I/usr/local/opt/openssl/include"
-	LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl/lib"
-	;;
+  case "$(uname -m)" in
+    arm64)
+      CPPFLAGS="${CPPFLAGS} -I/opt/homebrew/opt/openssl/include"
+      LDFLAGS="${LDFLAGS} -L/opt/homebrew/opt/openssl/lib"
+      ;;
+    **)
+      CPPFLAGS="${CPPFLAGS} -I/usr/local/opt/openssl/include"
+      LDFLAGS="${LDFLAGS} -L/usr/local/opt/openssl/lib"
+      ;;
+  esac
+  ;;
 esac
 ])# CHECK_DARWIN_PATHS


### PR DESCRIPTION
Currently, when macOS users clone tarsnap and try to run `./configure`, M1 and M2 macs will run into an error saying they're missing OpenSSL:

```
~/ml/tarsnap $ ./configure
checking build system type... aarch64-apple-darwin22.5.0
checking host system type... aarch64-apple-darwin22.5.0
checking target system type... aarch64-apple-darwin22.5.0
...
checking for openssl/rsa.h... no
configure: error: *** OpenSSL header files missing ***
```

This PR detects whether the system is running arm64, and if so, searches `/opt/homebrew` instead of `/usr/local`.

The effect is that all macOS users (whether on Intel or Apple silicon) can clone tarsnap, run `autoreconf && ./configure && make -j12` and the build process will work, assuming they've run `brew install openssl`.