### PR TITLE
Elastic array wrap around bug

### DIFF
--- a/libcperciva/datastruct/elasticarray.c
+++ b/libcperciva/datastruct/elasticarray.c
@@ -30,7 +30,7 @@ resize(struct elasticarray * EA, size_t nsize)
 		nalloc = EA->alloc * 2;
 		if (nalloc < nsize)
 			nalloc = nsize;
-	} else if (EA->alloc > nsize * 4) {
+	} else if (EA->alloc / 4 > nsize) {
 		/* We need to shrink the buffer. */
 		nalloc = nsize * 2;
 	} else {

--- a/libcperciva/datastruct/elasticarray.c
+++ b/libcperciva/datastruct/elasticarray.c
@@ -28,6 +28,12 @@ resize(struct elasticarray * EA, size_t nsize)
 	if (EA->alloc < nsize) {
 		/* We need to enlarge the buffer. */
 		nalloc = EA->alloc * 2;
+		/*
+		 * Handle if nalloc is not large enough to hold nsize, which can
+		 * happen when: 1) EA->alloc is small enough that EA->alloc * 2
+		 * is still smaller than nsize, or 2) EA->alloc is large enough
+		 * that EA->alloc * 2 wraps around, becoming smaller than nsize.
+		 */
 		if (nalloc < nsize)
 			nalloc = nsize;
 	} else if (EA->alloc / 4 > nsize) {


### PR DESCRIPTION
Commits picked up from https://github.com/Tarsnap/tarsnap/pull/592. 

Two things:
1. There was a unsigned wrap around bug in the elasticarray resize code which could cause the buffer to become smaller than the given nsize. I don't really know if it could happen in practice or what problems could be caused in case it happens.
2. Added a comment explaining that another wrap around is actually handled as it was unclear from just the code.