### PR TITLE
Refactor crypto_keys_init

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -130,6 +130,7 @@ lib_libtarsnap_a_SOURCES=						\
 	lib/crypto/crypto_hash.c					\
 	lib/crypto/crypto_internal.h					\
 	lib/crypto/crypto_keys.c					\
+	lib/crypto/crypto_keys_init.c					\
 	lib/crypto/crypto_keys_server.c					\
 	lib/crypto/crypto_keys_subr.c					\
 	lib/crypto/crypto_passwd_to_dh.c				\

--- a/lib/crypto/crypto.h
+++ b/lib/crypto/crypto.h
@@ -89,7 +89,7 @@ typedef struct crypto_session_internal CRYPTO_SESSION;
 
 /**
  * crypto_keys_init(void):
- * Initialize the key cache.
+ * Initialize cryptographic keys.
  */
 int crypto_keys_init(void);
 

--- a/lib/crypto/crypto_internal.h
+++ b/lib/crypto/crypto_internal.h
@@ -92,6 +92,12 @@ void crypto_keys_subr_free_HMAC(struct crypto_hmac_key **);
 int crypto_file_init_keys(void);
 
 /**
+ * crypto_keys_init_keycache(void):
+ * Initialize the key cache.
+ */
+int crypto_keys_init_keycache(void);
+
+/**
  * crypto_MGF1(seed, seedlen, buf, buflen):
  * The MGF1 mask generation function, as specified in RFC 3447 section B.2.1,
  * using SHA256 as the hash function.

--- a/lib/crypto/crypto_keys_init.c
+++ b/lib/crypto/crypto_keys_init.c
@@ -1,0 +1,56 @@
+#include <stdint.h>
+
+#include <openssl/err.h>
+#include <openssl/rand.h>
+
+#include "crypto_entropy.h"
+#include "warnp.h"
+
+#include "crypto.h"
+#include "crypto_internal.h"
+
+/* Amount of entropy to use for seeding OpenSSL. */
+#define RANDBUFLEN	2048
+
+/**
+ * crypto_keys_init(void):
+ * Initialize cryptographic keys.
+ */
+int
+crypto_keys_init(void)
+{
+	uint8_t randbuf[RANDBUFLEN];
+
+	/* Initialize key cache. */
+	if (crypto_keys_init_keycache())
+		goto err0;
+
+	/* Load OpenSSL error strings. */
+	ERR_load_crypto_strings();
+
+	/* Seed OpenSSL entropy pool. */
+	if (crypto_entropy_read(randbuf, RANDBUFLEN)) {
+		warnp("Could not obtain sufficient entropy");
+		goto err0;
+	}
+	RAND_seed(randbuf, RANDBUFLEN);
+
+	/* Load server root public key. */
+	if (crypto_keys_server_import_root()) {
+		warn0("Could not import server root public key");
+		goto err0;
+	}
+
+	/* Initialize keys owned by crypto_file. */
+	if (crypto_file_init_keys()) {
+		warn0("Could not initialize crypto_file keys");
+		goto err0;
+	}
+
+	/* Success! */
+	return (0);
+
+err0:
+	/* Failure! */
+	return (-1);
+}


### PR DESCRIPTION
Move bits which don't deal directly with keys into a new file crypto_keys_init.c in order to avoid linkage pollution issues.