### PR TITLE
Fix concatenated words in error messages

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -1333,7 +1333,7 @@ main(int argc, char **argv)
 			bsdtar->return_value = 2;
 			bsdtar_warnc(bsdtar, 0,
 			    "Data on server was modified, but it might not"
-			    "be exactly what you requested");
+			    " be exactly what you requested");
 		}
 	}
 	return (bsdtar->return_value);
@@ -1942,7 +1942,7 @@ dooption(struct bsdtar *bsdtar, const char * conf_opt,
 		if (passphrase_entry_parse(conf_arg,
 		    &bsdtar->option_passphrase_entry, &str))
 			bsdtar_errc(bsdtar, 1, 0, "Cannot parse passphrase"
-			    "entry method: %s", conf_arg);
+			    " entry method: %s", conf_arg);
 		if ((bsdtar->option_passphrase_arg = strdup(str)) == NULL)
 			bsdtar_errc(bsdtar, 1, ENOMEM,
 			    "Cannot allocate memory");

--- a/tar/util.c
+++ b/tar/util.c
@@ -467,7 +467,7 @@ do_chdir(struct bsdtar *bsdtar)
 		return;
 
 	if (chdir(bsdtar->pending_chdir) != 0) {
-		bsdtar_errc(bsdtar, 1, 0, "could not chdir to '%s'\n",
+		bsdtar_errc(bsdtar, 1, 0, "could not chdir to '%s'",
 		    bsdtar->pending_chdir);
 	}
 	free(bsdtar->pending_chdir);


### PR DESCRIPTION
Also drop a redundant newline.