### PR TITLE
pkg: use https URL for DEP5 d/copyright file

### DIFF
--- a/pkg/debian/copyright
+++ b/pkg/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: Tarsnap
 Upstream-Contact: Colin Percival <cperciva@tarsnap.com>
 Source: https://tarsnap.com/download.html


### PR DESCRIPTION
Recommended in the updated specification: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/#format-field