### PR TITLE
apisupport.sh: pass ${LDFLAGS} when testing for api features

### DIFF
--- a/libcperciva/apisupport/Build/apisupport.sh
+++ b/libcperciva/apisupport/Build/apisupport.sh
@@ -38,7 +38,7 @@ feature() {
 	for API_CFLAGS in "$@"; do
 		if ${CC} ${CPPFLAGS} ${CFLAGS} ${CFLAGS_HARDCODED}	\
 		    ${API_CFLAGS} "${feature_filename}" ${LDADD_EXTRA}	\
-		    ${EXTRALIB}	2>>"${outcc}"; then
+		    ${EXTRALIB}	${LDFLAGS} 2>>"${outcc}"; then
 			rm -f a.out
 			break;
 		fi


### PR DESCRIPTION
I'm trying to create a recipe for building the tarsnap client with Yocto, in both native and target variants.

One problem I've hit for the native variant is that Yocto tries very hard to rely on host tools as little as possible, and builds as many native tools and libraries as possible, in order to have a reproducible build environment.

So Yocto does rely on the build host providing a working C compiler, but something like openssl is built using that, and then any other native tools that need openssl will be linked against that specific version. To that end, Yocto ensures that all recipes have a value of LDFLAGS set appropriately, e.g.

export LDFLAGS="-L[...]/x86_64-linux/tarsnap-native/1.0.41/recipe-sysroot-native/usr/lib [...]"

However, this is not taken into account in the api support detection logic. So the first attempt to build
apisupport-LIBCRYPTO-LOW_LEVEL_AES.c fails as expected due to the deprecation

  error: ‘AES_set_encrypt_key’ is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]
   11 |         AES_set_encrypt_key(key_unexpanded, 128, &kexp_actual);
      |         ^~~~~~~~~~~~~~~~~~~
  In file included from ../sources/tarsnap-autoconf-1.0.41/libcperciva/apisupport/Build/apisupport-LIBCRYPTO-LOW_LEVEL_AES.c:3:
  [...]/x86_64-linux/tarsnap-native/1.0.41/recipe-sysroot-native/usr/include/openssl/aes.h:50:5: note: declared here
   50 | int AES_set_encrypt_key(const unsigned char *userKey, const int bits,
      |     ^~~~~~~~~~~~~~~~~~~
  cc1: all warnings being treated as errors

But the second attempt including the -Wno... compiler flag also fails:

  [...]/hosttools/ld: cannot find -lcrypto: No such file or directory
  collect2: error: ld returned 1 exit status

Fix that by taking the user provided LDFLAGS into account.