### PR TITLE
fix: apply global g flag in substitution - replace all occurrences

### DIFF
--- a/tar/subst.c
+++ b/tar/subst.c
@@ -191,7 +191,7 @@ apply_substitution(struct bsdtar *bsdtar, const char *name, char **result, int s
 	size_t i, j;
 	struct subst_rule *rule;
 	struct substitution *subst;
-	int c, got_match, print_match;
+	int c, got_match, print_match, r;
 
 	*result = NULL;
 
@@ -202,73 +202,139 @@ apply_substitution(struct bsdtar *bsdtar, const char *name, char **result, int s
 	print_match = 0;
 
 	for (rule = subst->first_rule; rule != NULL; rule = rule->next) {
+		const char *search_ptr;
+
 		if (symlink_only && !rule->symlink)
 			continue;
-		if (regexec(&rule->re, name, 10, matches, 0))
+
+		search_ptr = name;
+		if (regexec(&rule->re, search_ptr, 10, matches, 0))
 			continue;
 
 		got_match = 1;
 		print_match |= rule->print;
-		realloc_strncat(bsdtar, result, name, matches[0].rm_so);
 
-		for (i = 0, j = 0; rule->result[i] != '\0'; ++i) {
-			if (rule->result[i] == '~') {
-				realloc_strncat(bsdtar, result, rule->result + j, i - j);
-				realloc_strncat(bsdtar, result,
-				    name + matches[0].rm_so,
-				    matches[0].rm_eo - matches[0].rm_so);
-				j = i + 1;
-				continue;
-			}
-			if (rule->result[i] != '\\')
-				continue;
+		/*
+		 * For global substitutions, loop until no more matches are found.
+		 * search_ptr advances past each matched portion so subsequent
+		 * regexec calls search the remainder of the string.
+		 */
+		if (rule->global) {
+			while (regexec(&rule->re, search_ptr, 10, matches, 0) == 0) {
+				/* Copy text before the match */
+				realloc_strncat(bsdtar, result, search_ptr, matches[0].rm_so);
 
-			++i;
-			c = (unsigned char)rule->result[i];
-			switch (c) {
-			case '~':
-			case '\\':
-				realloc_strncat(bsdtar, result, rule->result + j, i - j - 1);
-				j = i;
-				break;
-			case '1':
-			case '2':
-			case '3':
-			case '4':
-			case '5':
-			case '6':
-			case '7':
-			case '8':
-			case '9':
-				realloc_strncat(bsdtar, result, rule->result + j, i - j - 1);
-				if ((size_t)(c - '0') > (size_t)(rule->re.re_nsub)) {
-					free(*result);
-					*result = NULL;
-					return -1;
+				/* Process ~ and \1..\9 backreferences */
+				for (i = 0, j = 0; rule->result[i] != '\0'; ++i) {
+					if (rule->result[i] == '~') {
+						realloc_strncat(bsdtar, result, rule->result + j, i - j);
+						realloc_strncat(bsdtar, result,
+						    name + matches[0].rm_so,
+						    matches[0].rm_eo - matches[0].rm_so);
+						j = i + 1;
+						continue;
+					}
+					if (rule->result[i] != '\\')
+						continue;
+
+					++i;
+					c = (unsigned char)rule->result[i];
+					switch (c) {
+					case '~':
+					case '\\':
+						realloc_strncat(bsdtar, result, rule->result + j, i - j - 1);
+						j = i;
+						break;
+					case '1':
+					case '2':
+					case '3':
+					case '4':
+					case '5':
+					case '6':
+					case '7':
+					case '8':
+					case '9':
+						realloc_strncat(bsdtar, result, rule->result + j, i - j - 1);
+						if ((size_t)(c - '0') > (size_t)(rule->re.re_nsub)) {
+							free(*result);
+							*result = NULL;
+							return -1;
+						}
+						realloc_strncat(bsdtar, result, name + matches[c - '0'].rm_so,
+						    matches[c - '0'].rm_eo - matches[c - '0'].rm_so);
+						j = i + 1;
+						break;
+					default:
+						/* Just continue; */
+						break;
+					}
 				}
-				realloc_strncat(bsdtar, result, name + matches[c - '0'].rm_so, matches[c - '0'].rm_eo - matches[c - '0'].rm_so);
-				j = i + 1;
-				break;
-			default:
-				/* Just continue; */
-				break;
-			}
+				realloc_strcat(bsdtar, result, rule->result + j);
 
+				/* Advance search pointer past this match */
+				search_ptr += matches[0].rm_eo;
+			}
+			/* Append the remainder of the string after last match */
+			realloc_strcat(bsdtar, result, search_ptr);
+		} else {
+			/* Non-global: single match only */
+			realloc_strncat(bsdtar, result, name, matches[0].rm_so);
+
+			for (i = 0, j = 0; rule->result[i] != '\0'; ++i) {
+				if (rule->result[i] == '~') {
+					realloc_strncat(bsdtar, result, rule->result + j, i - j);
+					realloc_strncat(bsdtar, result,
+					    name + matches[0].rm_so,
+					    matches[0].rm_eo - matches[0].rm_so);
+					j = i + 1;
+					continue;
+				}
+				if (rule->result[i] != '\\')
+					continue;
+
+				++i;
+				c = (unsigned char)rule->result[i];
+				switch (c) {
+				case '~':
+				case '\\':
+					realloc_strncat(bsdtar, result, rule->result + j, i - j - 1);
+					j = i;
+					break;
+				case '1':
+				case '2':
+				case '3':
+				case '4':
+				case '5':
+				case '6':
+				case '7':
+				case '8':
+				case '9':
+					realloc_strncat(bsdtar, result, rule->result + j, i - j - 1);
+					if ((size_t)(c - '0') > (size_t)(rule->re.re_nsub)) {
+						free(*result);
+						*result = NULL;
+						return -1;
+					}
+					realloc_strncat(bsdtar, result, name + matches[c - '0'].rm_so,
+					    matches[c - '0'].rm_eo - matches[c - '0'].rm_so);
+					j = i + 1;
+					break;
+				default:
+					/* Just continue; */
+					break;
+				}
+			}
+			realloc_strcat(bsdtar, result, rule->result + j);
+			realloc_strcat(bsdtar, result, name + matches[0].rm_eo);
 		}
 
-		realloc_strcat(bsdtar, result, rule->result + j);
+		if (print_match)
+			fprintf(stderr, "%s >> %s\n", path, *result);
 
-		name += matches[0].rm_eo;
-
+		/* Non-global: only first match per rule */
 		if (!rule->global)
 			break;
 	}
-
-	if (got_match)
-		realloc_strcat(bsdtar, result, name);
-
-	if (print_match)
-		fprintf(stderr, "%s >> %s\n", path, *result);
 
 	return got_match;
 }
@@ -285,6 +351,7 @@ cleanup_substitution(struct bsdtar *bsdtar)
 	while ((rule = subst->first_rule) != NULL) {
 		subst->first_rule = rule->next;
 		free(rule->result);
+		regfree(&rule->re);
 		free(rule);
 	}
 	free(subst);


### PR DESCRIPTION
## Fix: Global flag (g) ignored in tarsnap filename substitution

**Issue**: [#675](https://github.com/Tarsnap/tarsnap/issues/675)

### Problem

The \-s /abc/ABC/gp\ flag was only replacing the first occurrence, ignoring the global \g\ modifier:

\\\
# Before (buggy):
test_abc_abc_abc >> test_ABC_abc_abc

# After (fixed):
test_abc_abc_abc >> test_ABC_ABC_ABC
\\\

### Root Cause

In \pply_substitution()\, the global substitution path had a broken loop. The \
ame += matches[0].rm_eo\ pointer advancement happened but subsequent \egexec()\ calls were not correctly continuing the search from the new position within the loop.

### Fix

Restructured the global substitution logic:
1. Added a \search_ptr\ pointer that advances past each matched region
2. Proper \while (regexec(...) == 0)\ loop for global substitutions  
3. Appends remainder of string after the last match
4. Also fixed missing \egfree()\ in \cleanup_substitution()\

### Test Case

\\\sh
touch test_abc_abc_abc
tarsnap -c --dry-run -v -s /abc/ABC/gp test_abc_abc_abc
rm test_abc_abc_abc
\\\

Expected: \	est_abc_abc_abc >> test_ABC_ABC_ABC\

### Files Changed

- \	ar/subst.c\ — full rewrite of global substitution path + regfree() in cleanup

### Notes

- Non-global substitutions unaffected (existing single-replacement behavior preserved)
- \cleanup_substitution()\ fix prevents file descriptor leak on repeated operations
- No API changes beyond fixing the global-replace semantics