### PR TITLE
Fix global path substitutions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -711,6 +711,7 @@ EXTRA_DIST+=								\
 	tests/07-selecting-files-nT-full.good				\
 	tests/07-selecting-files-nT-partial.good			\
 	tests/07-selecting-files.sh					\
+	tests/08-substitution.sh					\
 	tests/fake-passphrased.keys					\
 	tests/fake.keys							\
 	tests/shared_test_functions.sh					\

--- a/tar/subst.c
+++ b/tar/subst.c
@@ -191,7 +191,7 @@ apply_substitution(struct bsdtar *bsdtar, const char *name, char **result, int s
 	size_t i, j;
 	struct subst_rule *rule;
 	struct substitution *subst;
-	int c, got_match, print_match;
+	int c, got_match, is_end, print_match;
 
 	*result = NULL;
 
@@ -204,6 +204,8 @@ apply_substitution(struct bsdtar *bsdtar, const char *name, char **result, int s
 	for (rule = subst->first_rule; rule != NULL; rule = rule->next) {
 		if (symlink_only && !rule->symlink)
 			continue;
+next_match:
+		is_end = (*name == '\0');
 		if (regexec(&rule->re, name, 10, matches, 0))
 			continue;
 
@@ -258,7 +260,15 @@ apply_substitution(struct bsdtar *bsdtar, const char *name, char **result, int s
 
 		realloc_strcat(bsdtar, result, rule->result + j);
 
-		name += matches[0].rm_eo;
+		if (matches[0].rm_eo > 0) {
+			name += matches[0].rm_eo;
+		} else if (!is_end) {
+			realloc_strncat(bsdtar, result, name, 1);
+			name++;
+		}
+
+		if (rule->global && !is_end)
+			goto next_match;
 
 		if (!rule->global)
 			break;

--- a/tests/08-substitution.sh
+++ b/tests/08-substitution.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+### Constants
+c_valgrind_min=1
+samplefile=${s_basename}-test_abc_abc_abc
+substitution_stderr=${s_basename}-substitution.stderr
+
+scenario_cmd() {
+	# Check that the global flag replaces all matches in a pathname.
+	setup_check "check global substitution"
+	touch "${samplefile}"
+	${c_valgrind_cmd} ./tarsnap --no-default-config		\
+		-c --dry-run -v -s /abc/ABC/gp			\
+		"${samplefile}"					\
+		2> "${substitution_stderr}"
+	echo $? > "${c_exitfile}"
+
+	setup_check "check global substitution output"
+	grep -q "test_abc_abc_abc >> .*test_ABC_ABC_ABC"	\
+		"${substitution_stderr}"
+	echo $? > "${c_exitfile}"
+}


### PR DESCRIPTION
Fixes #675.

## Summary
- Apply a global substitution rule repeatedly against the remaining pathname.
- Advance after zero-length matches so a global rule cannot retry the same position forever.
- Add a regression test for `-s /abc/ABC/gp` replacing every match in a pathname.

## Testing
- `env N=8 VERBOSE=1 ./tests/test_tarsnap.sh .`
- `env VERBOSE=1 ./tests/test_tarsnap.sh .` (04-c-d-real-keyfile skipped; no `TARSNAP_TEST_KEYFILE` configured)