### PR TITLE
Fix tarsnap-recrypt cachedir option names

### DIFF
--- a/recrypt/recrypt.c
+++ b/recrypt/recrypt.c
@@ -455,9 +455,9 @@ main(int argc, char **argv)
 		usage();
 
 	/* Make sure the cache directories exist. */
-	if (build_dir(ncachedir, "--newcachdir"))
+	if (build_dir(ncachedir, "--newcachedir"))
 		exit(1);
-	if (build_dir(ocachedir, "--oldcachdir"))
+	if (build_dir(ocachedir, "--oldcachedir"))
 		exit(1);
 
 	/* Lock the cache directories. */


### PR DESCRIPTION
Fixes #679.

`tarsnap-recrypt` accepts `--newcachedir` and `--oldcachedir`, but passed the misspelled labels `--newcachdir` and `--oldcachdir` into `build_dir`. Since `build_dir` includes that label in directory-creation diagnostics, users could see non-existent option names.

Verified locally:

```sh
autoreconf -i
./configure CPPFLAGS="-I/opt/homebrew/opt/openssl@3/include" LDFLAGS="-L/opt/homebrew/opt/openssl@3/lib"
make -j$(sysctl -n hw.ncpu)
```

I also ran `tarsnap-recrypt` with temporary cache directories and missing dummy key paths to confirm the diagnostic now prints `--newcachedir` and `--oldcachedir`.
