### PR TITLE
Fix additional libarchive comment typos

### DIFF
--- a/libarchive/archive_entry_stat.c
+++ b/libarchive/archive_entry_stat.c
@@ -110,7 +110,7 @@ archive_entry_stat(struct archive_entry *entry)
 	/*
 	 * TODO: On Linux, store 32 or 64 here depending on whether
 	 * the cached stat structure is a stat32 or a stat64.  This
-	 * will allow us to support both variants interchangably.
+	 * will allow us to support both variants interchangeably.
 	 */
 	entry->stat_valid = 1;
 

--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -227,7 +227,7 @@ __archive_errx(int retvalue, const char *msg)
  *        (This "compression=9" option entry is for "zip" format only)
  *
  *      If another entries follow it, those are not for
- *      the specfic format/filter.
+ *      the specific format/filter.
  *        e.g  handle "zip:compression=9,opt=XXX,opt-b=ZZZ"
  *          "zip" format/filter handler will get "compression=9"
  *          all format/filter handler will get "opt=XXX"

--- a/libarchive/archive_windows.c
+++ b/libarchive/archive_windows.c
@@ -536,7 +536,7 @@ la_chmod(const char *path, mode_t mode)
 }
 
 /*
- * This fcntl is limited implemention.
+ * This fcntl is limited implementation.
  */
 int
 la_fcntl(int fd, int cmd, int val)
@@ -619,7 +619,7 @@ la_mkdir(const char *path, mode_t mode)
 	return (0);
 }
 
-/* Windows' mbstowcs is differrent error handling from other unix mbstowcs.
+/* Windows' mbstowcs has different error handling from other Unix mbstowcs.
  * That one is using MultiByteToWideChar function with MB_PRECOMPOSED and
  * MB_ERR_INVALID_CHARS flags.
  * This implements for only to pass libarchive_test.
@@ -691,7 +691,7 @@ la_open(const char *path, int flags, ...)
 	if (ws == NULL) {
 		r = _open(path, flags, pmode);
 		if (r < 0 && errno == EACCES && (flags & O_CREAT) != 0) {
-			/* simular other POSIX system action to pass a test */
+			/* Match other POSIX systems' behavior to pass a test. */
 			attr = GetFileAttributesA(path);
 			if (attr == -1)
 				_dosmaperr(GetLastError());
@@ -711,7 +711,7 @@ la_open(const char *path, int flags, ...)
 	}
 	r = _wopen(ws, flags, pmode);
 	if (r < 0 && errno == EACCES && (flags & O_CREAT) != 0) {
-		/* simular other POSIX system action to pass a test */
+		/* Match other POSIX systems' behavior to pass a test. */
 		attr = GetFileAttributesW(ws);
 		if (attr == -1)
 			_dosmaperr(GetLastError());
@@ -817,7 +817,7 @@ fileTimeToUTC(const FILETIME *filetime, time_t *time, long *ns)
  * Windows' stat() does not accept path which is added "\\?\" especially "?"
  * character.
  * It means we cannot access a long name path(which is longer than MAX_PATH).
- * So I've implemented simular Windows' stat() to access the long name path.
+ * So I've implemented a similar Windows stat() to access the long name path.
  * And I've added some feature.
  * 1. set st_ino by nFileIndexHigh and nFileIndexLow of
  *    BY_HANDLE_FILE_INFORMATION.
@@ -1015,7 +1015,7 @@ la_unlink(const char *path)
 }
 
 /*
- * This waitpid is limited implemention.
+ * This waitpid is limited implementation.
  */
 pid_t
 la_waitpid(pid_t wpid, int *status, int option)


### PR DESCRIPTION
Summary:
- Fix several spelling mistakes in libarchive comments which are not covered by #683.
- Keep the changes limited to comments; no generated files or behavior are changed.

Tests:
- codespell libarchive/archive_entry_stat.c libarchive/archive_util.c libarchive/archive_windows.c
- git diff --cached --check before publishing

Related to #684.