### PR TITLE
Document XDG config file precedence in tarsnap.conf(5)

### DIFF
--- a/tar/tarsnap.conf.5-man.in
+++ b/tar/tarsnap.conf.5-man.in
@@ -13,12 +13,24 @@ file is read by the
 utility and specifies default options which will be
 ignored if the options in question are specified at
 the command line.
-Options may be specified in
+By default, options may be specified in the following files, listed
+from highest to lowest precedence:
+.RS 5
+.IP 1.
+\fI~/.tarsnaprc\fP
+.IP 2.
+\fI$XDG_CONFIG_HOME/tarsnap/tarsnap.conf\fP,
+or
+\fI~/.config/tarsnap/tarsnap.conf\fP
+if
+\fBXDG_CONFIG_HOME\fP
+is not set
+.IP 3.
 \fI@sysconfdir@/tarsnap.conf\fP
-and/or
-\fI~/.tarsnaprc\fP;
-if the two files conflict, the user's local configuration
-takes precedence.
+.RE
+If the files conflict, options from earlier files in this list take
+precedence.
+Command-line options override all default configuration files.
 .PP
 The
 \fB\%tarsnap.conf\fP
@@ -133,13 +145,33 @@ and
 \fBno-*\fP
 options are only useful in the user-specific
 \fI~/.tarsnaprc\fP
-configuration file, at which point they act to override options set in the
-global
+or XDG configuration file, at which point they act to override options set
+in the global
 \fI@sysconfdir@/tarsnap.conf\fP
 configuration file.
 .SH FILES
 .ad l
 .RS 5
+.TP
+.B ~/.tarsnaprc
+The highest-precedence default
+\fB\%tarsnap.conf\fP
+configuration file for the current user.
+Parameters specified here take effect unless they are
+specified via the command line.
+.TP
+.B $XDG_CONFIG_HOME/tarsnap/tarsnap.conf
+A
+\fB\%tarsnap.conf\fP
+configuration file for the current user.
+If the environment variable
+\fBXDG_CONFIG_HOME\fP
+is not set, the default value of
+\fI~/.config/tarsnap/tarsnap.conf\fP
+will be used.
+Parameters specified here take effect unless they are specified via
+\fI~/.tarsnaprc\fP
+or the command line.
 .TP
 .B @sysconfdir@/tarsnap.conf
 The system global
@@ -148,13 +180,6 @@ configuration file.
 Parameters specified here only take effect if they are not
 specified via the current user's local configuration file
 or via the command line.
-.TP
-.B ~/.tarsnaprc
-The
-\fB\%tarsnap.conf\fP
-configuration file for the current user.
-Parameters specified here take effect unless they are
-specified via the command line.
 .RE
 .SH SEE ALSO
 .ad l

--- a/tar/tarsnap.conf.5-mdoc.in
+++ b/tar/tarsnap.conf.5-mdoc.in
@@ -17,12 +17,24 @@ file is read by the
 utility and specifies default options which will be
 ignored if the options in question are specified at
 the command line.
-Options may be specified in
+By default, options may be specified in the following files, listed
+from highest to lowest precedence:
+.Bl -enum -compact
+.It
+.Pa ~/.tarsnaprc
+.It
+.Pa $XDG_CONFIG_HOME/tarsnap/tarsnap.conf ,
+or
+.Pa ~/.config/tarsnap/tarsnap.conf
+if
+.Ev XDG_CONFIG_HOME
+is not set
+.It
 .Pa @sysconfdir@/tarsnap.conf
-and/or
-.Pa ~/.tarsnaprc ;
-if the two files conflict, the user's local configuration
-takes precedence.
+.El
+If the files conflict, options from earlier files in this list take
+precedence.
+Command-line options override all default configuration files.
 .Pp
 The
 .Nm
@@ -94,12 +106,30 @@ and
 .Cm no-*
 options are only useful in the user-specific
 .Pa ~/.tarsnaprc
-configuration file, at which point they act to override options set in the
-global
+or XDG configuration file, at which point they act to override options set
+in the global
 .Pa @sysconfdir@/tarsnap.conf
 configuration file.
 .Sh FILES
 .Bl -tag -width indent
+.It Pa ~/.tarsnaprc
+The highest-precedence default
+.Nm
+configuration file for the current user.
+Parameters specified here take effect unless they are
+specified via the command line.
+.It Pa $XDG_CONFIG_HOME/tarsnap/tarsnap.conf
+A
+.Nm
+configuration file for the current user.
+If the environment variable
+.Ev XDG_CONFIG_HOME
+is not set, the default value of
+.Pa ~/.config/tarsnap/tarsnap.conf
+will be used.
+Parameters specified here take effect unless they are specified via
+.Pa ~/.tarsnaprc
+or the command line.
 .It Pa @sysconfdir@/tarsnap.conf
 The system global
 .Nm
@@ -107,12 +137,6 @@ configuration file.
 Parameters specified here only take effect if they are not
 specified via the current user's local configuration file
 or via the command line.
-.It Pa ~/.tarsnaprc
-The
-.Nm
-configuration file for the current user.
-Parameters specified here take effect unless they are
-specified via the command line.
 .El
 .Sh SEE ALSO
 .Xr tarsnap 1


### PR DESCRIPTION
Fixes #686.

Summary:
- Document the XDG per-user config path in tarsnap.conf(5).
- Clarify default config precedence: ~/.tarsnaprc, XDG config, then @sysconfdir@/tarsnap.conf.
- Keep the mdoc and man input files consistent.

Validation:
- git diff --check
- mandoc -Tascii tar/tarsnap.conf.5-mdoc.in
- mandoc -Tascii -man tar/tarsnap.conf.5-man.in

Note: This is submitted as a documentation clarity patch. I am not asserting any payout eligibility; any Tarsnap bounty/account-credit handling can be discussed after maintainer review.