### PR TITLE
docs: add XDG per-user config file to tarsnap.conf(5)

### DIFF
--- a/tar/tarsnap.conf.5-man.in
+++ b/tar/tarsnap.conf.5-man.in
@@ -147,6 +147,20 @@ The system global
 configuration file.
 Parameters specified here only take effect if they are not
 specified via the current user's local configuration file
+or via the per-user XDG configuration file
+or via the command line.
+.TP
+.B $XDG_CONFIG_HOME/tarsnap/tarsnap.conf
+The XDG per-user
+\fB\%tarsnap.conf\fP
+configuration file.
+If
+\fB\%XDG_CONFIG_HOME\fP
+is unset,
+.B ~/.config/tarsnap/tarsnap.conf
+is used instead.
+Parameters specified here take effect unless they are
+specified via the current user's local configuration file
 or via the command line.
 .TP
 .B ~/.tarsnaprc

--- a/tar/tarsnap.conf.5-mdoc.in
+++ b/tar/tarsnap.conf.5-mdoc.in
@@ -106,6 +106,19 @@ The system global
 configuration file.
 Parameters specified here only take effect if they are not
 specified via the current user's local configuration file
+or via the per-user XDG configuration file
+or via the command line.
+.It Pa $XDG_CONFIG_HOME/tarsnap/tarsnap.conf
+The XDG per-user
+.Nm
+configuration file.
+If
+.Ev XDG_CONFIG_HOME
+is unset,
+.Pa ~/.config/tarsnap/tarsnap.conf
+is used instead.
+Parameters specified here take effect unless they are
+specified via the current user's local configuration file
 or via the command line.
 .It Pa ~/.tarsnaprc
 The


### PR DESCRIPTION
Fixes #686.

The `tarsnap.conf(5)` manual page did not mention the XDG per-user config file precedence (`~/.config/tarsnap/tarsnap.conf` or `$XDG_CONFIG_HOME/tarsnap/tarsnap.conf`), even though the client explicitly evaluates it between `~/.tarsnaprc` and the system-wide config file.

This PR adds the missing documentation to both the man and mdoc variants.

Bounty Wallet: 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp (Solana)