### PR TITLE
Fix misspelled cachedir option names in recrypt diagnostics

### DIFF
--- a/recrypt/recrypt.c
+++ b/recrypt/recrypt.c
@@ -455,9 +455,9 @@ main(int argc, char **argv)
 		usage();
 
 	/* Make sure the cache directories exist. */
-	if (build_dir(ncachedir, "--newcachdir"))
+	if (build_dir(ncachedir, "--newcachedir"))
 		exit(1);
-	if (build_dir(ocachedir, "--oldcachdir"))
+	if (build_dir(ocachedir, "--oldcachedir"))
 		exit(1);
 
 	/* Lock the cache directories. */


### PR DESCRIPTION
Fixes #679.

Change build_dir diagnostics in recrypt/recrypt.c to use correct option names:
- --newcachedir
- --oldcachedir

This updates user-facing directory creation messages so they match accepted CLI flags.