### PR TITLE
Fix typo in bsdtar Windows comment

### DIFF
--- a/tar/bsdtar_windows.c
+++ b/tar/bsdtar_windows.c
@@ -1124,7 +1124,7 @@ bsdtar_is_privileged(struct bsdtar *bsdtar)
 }
 
 /*
- * Note: We should use wide-character for findng '\' character,
+ * Note: We should use wide-character for finding '\' character,
  * a directory separator on Windows, because some character-set have
  * been using the '\' character for a part of its multibyte character
  * code.


### PR DESCRIPTION
## Summary
- Fix a cosmetic typo in a Windows-specific bsdtar comment: findng -> finding.

## Validation
- Ran git diff --check.

Related to #684.