### PR TITLE
Clarify SSE2 smix comment

### DIFF
--- a/lib-platform/crypto/crypto_scrypt.c
+++ b/lib-platform/crypto/crypto_scrypt.c
@@ -214,7 +214,7 @@ selectsmix(void)
 #ifdef CPUSUPPORT_X86_SSE2
 	/* If we're running on an SSE2-capable CPU, try that code. */
 	if (cpusupport_x86_sse2()) {
-		/* If SSE2ized smix works, use it. */
+		/* If SSE2-optimized smix works, use it. */
 		if (!testsmix(crypto_scrypt_smix_sse2)) {
 			smix_func = crypto_scrypt_smix_sse2;
 			return;


### PR DESCRIPTION
## Summary
- Clarify a comment in the SSE2 smix selection path: SSE2ized -> SSE2-optimized.

## Validation
- Ran git diff --check.

Related to #684.