### PR TITLE
Fix remaining typo comments

### DIFF
--- a/lib-platform/network/tsnetwork_cork.c
+++ b/lib-platform/network/tsnetwork_cork.c
@@ -18,7 +18,8 @@
  * XXX 1. To avoid wasting bandwidth, by ensuring that multiple small writes
  * XXX over a socket are aggregated into a single TCP/IP packet.
  * XXX 2. To avoid severe performance issues which would otherwise result
- * XXX from nagling, by allowing data to be "pushed" out once there are no
+ * XXX from Nagle's algorithm, by allowing data to be "pushed" out once there
+ * XXX are no
  * XXX more writes queued.
  * XXX
  * XXX POSIX defines TCP_NODELAY for purpose #2, although it does not require

--- a/libarchive/archive_entry_stat.c
+++ b/libarchive/archive_entry_stat.c
@@ -110,7 +110,7 @@ archive_entry_stat(struct archive_entry *entry)
 	/*
 	 * TODO: On Linux, store 32 or 64 here depending on whether
 	 * the cached stat structure is a stat32 or a stat64.  This
-	 * will allow us to support both variants interchangably.
+	 * will allow us to support both variants interchangeably.
 	 */
 	entry->stat_valid = 1;
 

--- a/libarchive/archive_util.c
+++ b/libarchive/archive_util.c
@@ -227,7 +227,7 @@ __archive_errx(int retvalue, const char *msg)
  *        (This "compression=9" option entry is for "zip" format only)
  *
  *      If another entries follow it, those are not for
- *      the specfic format/filter.
+ *      the specific format/filter.
  *        e.g  handle "zip:compression=9,opt=XXX,opt-b=ZZZ"
  *          "zip" format/filter handler will get "compression=9"
  *          all format/filter handler will get "opt=XXX"

--- a/libarchive/archive_windows.c
+++ b/libarchive/archive_windows.c
@@ -536,7 +536,7 @@ la_chmod(const char *path, mode_t mode)
 }
 
 /*
- * This fcntl is limited implemention.
+ * This fcntl is a limited implementation.
  */
 int
 la_fcntl(int fd, int cmd, int val)
@@ -1015,7 +1015,7 @@ la_unlink(const char *path)
 }
 
 /*
- * This waitpid is limited implemention.
+ * This waitpid is a limited implementation.
  */
 pid_t
 la_waitpid(pid_t wpid, int *status, int option)


### PR DESCRIPTION
## Summary
- Fix the remaining cosmetic typos from the Tarsnap bounty issue in comments/docs.
- Covers: interchangably, specfic, implemention, and 
agling. 

## Validation
- Ran git diff --check.

Related to #684.