### PR TITLE
docs: fix packet hmac typo

### DIFF
--- a/lib/netpacket/packets.txt
+++ b/lib/netpacket/packets.txt
@@ -213,7 +213,7 @@ the ckptnonce value must be identical.
 
 The value nonce is the transaction nonce of the current write transaction.
 
-The value hmac is HMAC(0x13 || [packet minute final hmac]).
+The value hmac is HMAC(0x13 || [packet minus final hmac]).
 
 NETPACKET_TRANSACTION_CHECKPOINT_RESPONSE (0x93)
 ------------------------------------------------


### PR DESCRIPTION
## Summary
- Correct `packet minute final hmac` to `packet minus final hmac` in `lib/netpacket/packets.txt`.
- This matches the surrounding packet HMAC descriptions.

Fixes #694.

## Testing
- `rg -n "packet minute final hmac|packet minus final hmac" lib\netpacket\packets.txt`
- `git diff --check`

## AI disclosure
This pull request was prepared with assistance from OpenAI Codex.