### PR TITLE
Reject passphrase config option without argument

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -1938,6 +1938,8 @@ dooption(struct bsdtar *bsdtar, const char * conf_opt,
 	} else if (strcmp(conf_opt, "passphrase") == 0) {
 		if (bsdtar->option_passphrase_entry != PASSPHRASE_UNSET)
 			goto optset;
+		if (conf_arg == NULL)
+			goto needarg;
 
 		if (passphrase_entry_parse(conf_arg,
 		    &bsdtar->option_passphrase_entry, &str))


### PR DESCRIPTION
## Summary

Fixes #696 by making the passphrase configuration-file option follow the same missing-argument path as other argument-requiring options.

When passphrase appears without an argument, dooption() now jumps to the existing 
eedarg handler before calling passphrase_entry_parse(), avoiding the NULL dereference reported in the issue.

## Validation

- Inspected the current master implementation and confirmed passphrase was the only path here calling passphrase_entry_parse(conf_arg, ...) without a prior conf_arg == NULL guard.
- Confirmed the PR diff is limited to 	ar/bsdtar.c and adds only the existing-style conf_arg == NULL / goto needarg check.

I was unable to run a local build in this environment because repeated git clone attempts to GitHub failed with network connection resets/timeouts, so I submitted the minimal patch through the GitHub API.