### PR TITLE
**BUG BOUNTY: Integer overflow in `crypto_aesctr_stream_pre_wholeblock()` when `buflen` near `SIZE_M

### DIFF
--- a/libcperciva/crypto/crypto_aesctr_shared.c
+++ b/libcperciva/crypto/crypto_aesctr_shared.c
@@ -71,7 +71,7 @@ crypto_aesctr_stream_pre_wholeblock(struct crypto_aesctr * stream,
 	bytemod = stream->bytectr % 16;
 	if (bytemod != 0) {
 		/* Do we have enough to complete the request? */
-		if (bytemod + *buflen_p <= 16) {
+		if (*buflen_p <= 16 - bytemod) {
 			/* Process only buflen bytes, then return. */
 			crypto_aesctr_stream_cipherblock_use(stream, inbuf,
 			    outbuf, buflen_p, *buflen_p, bytemod);

--- a/tar/tarsnap.1-man
+++ b/tar/tarsnap.1-man
@@ -1,0 +1,1468 @@
+.TH TARSNAP 1 "@DATE@" ""
+.SH NAME
+.ad l
+\fB\%tarsnap\fP
+\- manipulate remote encrypted backups
+.SH SYNOPSIS
+.ad l
+.br
+\fB\%tarsnap\fP
+{\fB\-c\fP}
+\fB\--keyfile\fP \fIkey-file\fP
+\fB\--cachedir\fP \fIcache-dir\fP
+\fB\-f\fP \fIarchive-name\fP
+[\fIoptions\fP]
+[\fIfiles\fP | \fIdirectories\fP]
+.br
+\fB\%tarsnap\fP
+{\fB\-d\fP}
+\fB\--keyfile\fP \fIkey-file\fP
+\fB\--cachedir\fP \fIcache-dir\fP
+\fB\-f\fP \fIarchive-name\fP
+[\fIoptions\fP]
+.br
+\fB\%tarsnap\fP
+{\fB\-t\fP | \fB\-x\fP}
+\fB\--keyfile\fP \fIkey-file\fP
+\fB\-f\fP \fIarchive-name\fP
+[\fIoptions\fP]
+[\fIpatterns\fP]
+.br
+\fB\%tarsnap\fP
+{\fB\-r\fP}
+\fB\--keyfile\fP \fIkey-file\fP
+\fB\-f\fP \fIarchive-name\fP
+.br
+\fB\%tarsnap\fP
+{\fB\--list-archives\fP}
+\fB\--keyfile\fP \fIkey-file\fP
+.br
+\fB\%tarsnap\fP
+{\fB\--print-stats\fP}
+\fB\--keyfile\fP \fIkey-file\fP
+\fB\--cachedir\fP \fIcache-dir\fP
+[\fB\-f\fP \fIarchive-name\fP]
+.br
+\fB\%tarsnap\fP
+{\fB\--recover\fP}
+\fB\--keyfile\fP \fIkey-file\fP
+\fB\--cachedir\fP \fIcache-dir\fP
+.br
+\fB\%tarsnap\fP
+{\fB\--fsck\fP}
+\fB\--keyfile\fP \fIkey-file\fP
+\fB\--cachedir\fP \fIcache-dir\fP
+.br
+\fB\%tarsnap\fP
+{\fB\--fsck-prune\fP}
+\fB\--keyfile\fP \fIkey-file\fP
+\fB\--cachedir\fP \fIcache-dir\fP
+.br
+\fB\%tarsnap\fP
+{\fB\--initialize-cachedir\fP}
+\fB\--keyfile\fP \fIkey-file\fP
+\fB\--cachedir\fP \fIcache-dir\fP
+.br
+\fB\%tarsnap\fP
+{\fB\--nuke\fP}
+\fB\--keyfile\fP \fIkey-file\fP
+.br
+\fB\%tarsnap\fP
+\fB\--verify-config\fP
+.br
+\fB\%tarsnap\fP
+\fB\--version\fP
+.SH DESCRIPTION
+.ad l
+\fB\%tarsnap\fP
+creates, reads, deletes, and otherwise manages online backups.
+.PP
+The first option to
+\fB\%tarsnap\fP
+is a mode indicator from the following list:
+.RS 5
+.TP
+\fB\-c\fP
+Create an archive containing the specified items and name.
+.TP
+\fB\-d\fP
+Delete the specified archive.
+.TP
+\fB\-t\fP
+List archive contents to stdout.
+.TP
+\fB\-x\fP
+Extract to disk from the archive.
+.TP
+\fB\-r\fP
+Read the specified archive, convert it to a tar stream, and write it
+to stdout.
+.TP
+\fB\--list-archives\fP
+Print the names of archives stored.
+If the
+\fB\-v\fP
+flag is specified one or more times, the creation
+time of each archive is also printed;
+if the
+\fB\-v\fP
+flag is specified two or more times, the command
+line with which
+\fB\%tarsnap\fP
+was invoked to create each archive is also printed.
+.TP
+\fB\--print-stats\fP
+Print global statistics concerning the archives stored, and optionally
+information about individual archive(s).
+See "PRINTING ARCHIVE STATISTICS" below for information on the output format.
+.TP
+\fB\--recover\fP
+Recover a partial archive from a checkpoint if such an archive exists.
+This is also done automatically the next time an archive is created
+or deleted.
+.TP
+\fB\--fsck\fP
+Perform some integrity checks on the archives stored, and reconstruct the
+cache directory
+\fIcache-dir\fP.
+In the unlikely event that there are corrupted archives,
+\fB\%tarsnap\fP
+will exit and request that it be run with the
+\fB\--fsck-prune\fP
+option.
+.TP
+\fB\--fsck-prune\fP
+Run as
+\fB\--fsck\fP,
+but if corrupt archives are detected, prune the broken data.
+.TP
+\fB\--initialize-cachedir\fP
+Create and initialize the cachedir.
+This option is intended for the GUI and is not needed for command-line usage.
+.TP
+\fB\--nuke\fP
+Delete all of the archives stored.
+To protect against accidental data loss,
+\fB\%tarsnap\fP
+will ask you to type the text "No Tomorrow" when using the
+\fB\--nuke\fP
+command.
+.TP
+\fB\--verify-config\fP
+Check the configuration file(s) for syntactic errors.
+.TP
+\fB\--version\fP
+Print version number of
+\fB\%tarsnap\fP,
+and exit.
+.RE
+.PP
+In
+\fB\-c\fP
+mode, each specified file or directory is added to the
+archive in the order specified on the command line.
+By default, the contents of each directory are also archived.
+.PP
+In
+\fB\-t\fP
+or
+\fB\-x\fP
+mode, the entire command line
+is read and parsed before the archive is opened.
+The pathnames or patterns on the command line indicate
+which items in the archive should be processed.
+Patterns are shell-style globbing patterns as
+documented in
+\fBtcsh\fP(1).
+Note that these follow the POSIX rules for pattern matching, e.g.,
+`[]'
+are special characters which can be escaped with a backslash.
+.PP
+Two concurrent create or delete operations may not be performed with the same
+key.
+Extracting or listing archives may be performed in parallel with any other
+operation.
+.SH OPTIONS
+.ad l
+.RS 5
+.TP
+\fB@\fP\fIarchive-file\fP
+(c mode only)
+The specified archive file is read and the entries
+in it will be appended to the current archive.
+If
+\fIarchive-file\fP
+is
+``-''
+then the archive will be read from the standard input.
+As an example,
+.RS 4
+\fB\%tarsnap\fP \fB\-c\fP \fB\--keyfile\fP \fIkey-file\fP \fB\--cachedir\fP \fIcache-dir\fP \fB\-f\fP \fImybackup\fP \fB@\fP\fIbackup.tar\fP
+.RE
+reads the archive file
+\fIbackup.tar\fP
+from disk and stores it using
+\fB\%tarsnap\fP.
+.TP
+\fB@@\fP\fIarchive-name\fP
+(c mode only)
+The specified
+\fB\%tarsnap\fP
+archive is read and the entries in it will be
+appended to the current archive.
+.TP
+\fB\--aggressive-networking\fP
+(c mode only)
+Use multiple TCP connections to send data to the
+\fB\%tarsnap\fP
+server.
+If the upload rate is congestion-limited rather than
+being limited by individual bottleneck(s), this may
+allow tarsnap to use a significantly larger fraction
+of the available bandwidth, at the expense of slowing
+down any other network traffic.
+.TP
+\fB\--archive-names\fP \fIfilename\fP
+Read a list of archive names from
+\fIfilename\fP.
+.TP
+\fB\-C\fP \fIdirectory\fP
+(c and x modes only)
+In c mode, this changes the directory before adding
+the following files.
+In x mode, change directories after opening the archive
+but before extracting entries from the archive.
+.TP
+\fB\--cachedir\fP \fIcache-dir\fP
+(c, d, print-stats, and fsck modes only)
+Cache information about the archives stored by
+\fB\%tarsnap\fP
+in the directory
+\fIcache-dir\fP.
+The contents of this directory will not be backed up by
+\fB\%tarsnap\fP,
+so it should not be used for any other purpose.
+If the directory
+\fIcache-dir\fP
+is lost, it can be reconstructed by running
+\fB\%tarsnap\fP \fB\--fsck\fP.
+.TP
+\fB\--check-links\fP
+(c mode only)
+Issue a warning message unless all links to each file are archived.
+.TP
+\fB\--checkpoint-bytes\fP \fIbytespercheckpoint\fP
+(c mode only)
+Create a checkpoint after every
+\fIbytespercheckpoint\fP
+bytes of uploaded data.
+The value
+\fIbytespercheckpoint\fP
+must be at least 1000000, and a higher value is recommended since
+creating a checkpoint in an archive can take a few seconds and several
+hundred kB of bandwidth.
+.TP
+\fB\--chroot\fP
+(x mode only)
+\fB\%chroot\fP()
+to the current directory after processing any
+\fB\-C\fP
+options and before extracting any files.
+.TP
+\fB\--configfile\fP \fIfilename\fP
+Add
+\fIfilename\fP
+to the list of configuration files to be read; options set via these take
+priority over the default configuration files.
+This option can be specified multiple times, in which case all the files
+will be read; where settings conflict, the earlier configuration file will
+take priority.
+.TP
+\fB\--creationtime\fP \fIX\fP
+(c mode only)
+Manually specify a creation time (a unix timestamp) for the archive.
+This is unlikely to be useful when tarsnap is being invoked directly from the
+command line.
+.TP
+\fB\--csv-file\fP \fIfilename\fP
+(use with
+\fB\--print-stats\fP)
+Write statistics in CSV format to a file.
+.TP
+\fB\--disk-pause\fP \fIX\fP
+(c mode only)
+Pause for
+\fIX\fP
+ms between storing archive entries and after every 64 kB of file data.
+This will slow down
+\fB\%tarsnap\fP
+and thereby reduce its impact on other applications.
+For archiving files which are stored on an ATA disk and are not in the
+operating system disk cache, a value of
+\fB\--disk-pause\fP \fI10\fP
+will approximately double the time taken.
+.TP
+\fB\--dry-run\fP
+(c mode only)
+Don't really create an archive; just simulate doing so.
+The list of paths added to an archive (if the
+\fB\-v\fP
+option is used), progress messages (if the
+\fB\--progress-bytes\fP
+option is used), and final statistics printed (if the
+\fB\--print-stats\fP
+option is used) will be almost identical (typically
+within a few kB or a fraction of a percent) to if
+\fB\%tarsnap\fP
+is run without the
+\fB\--dry-run\fP
+option.
+.PP
+Note that the
+\fB\--maxbw\fP
+option does not work in combination with
+\fB\--dry-run\fP,
+since no bandwidth is actually used, and that since
+\fB\%tarsnap\fP
+does not contact the
+\fB\%tarsnap\fP
+server when performing a dry run, it will not detect an
+attempt to create an archive with the same name as one
+which already exists.
+If an existing archive is being copied via
+\fB@@\fP\fIarchive-name\fP,
+then some network bandwidth will be used while
+\fB\%tarsnap\fP
+reads metadata about
+\fIarchive-name\fP
+from the tarsnap server.
+.PP
+Furthermore,
+\fB\--dry-run\fP
+will not check whether the cache directory is out of sync.
+.TP
+\fB\--dry-run-metadata\fP
+(c mode only)
+Don't really create an archive; just simulate doing so.
+This is similar to
+\fB\--dry-run\fP,
+except that it doesn't read any files; it only processes filesystem metadata.
+.PP
+This is significantly faster than a regular
+\fB\--dry-run\fP,
+but it is still suitable for checking which filesystem entries will be
+archived (with
+\fB\-v\fP),
+or getting the total uncompressed archive size (via
+\fB\--totals\fP
+or
+\fB\--progress-bytes\fP).
+.PP
+This option cannot be used with
+\fB\--print-stats\fP.
+.TP
+\fB\--dump-config\fP
+Print out the command-line and all non-blank lines read from config files.
+.TP
+\fB\--exclude\fP \fIpattern\fP
+(c, x, and t modes only)
+Do not process files or directories that match the
+specified pattern.
+Note that exclusions take precedence over patterns or filenames
+specified on the command line.
+.TP
+\fB\-f\fP \fIarchive-name\fP
+(c, d, x, t, r, list-archives, and print-stats modes only)
+Operate on the archive
+\fIarchive-name\fP.
+In mode c, if archive creation is interrupted by \&^Q,
+the SIGQUIT signal, or reaching the bandwidth limit
+specified via a
+\fB\--maxbw\fP
+option, the archive will be stored with
+".part" appended to its name.
+In mode print-stats, if
+\fIarchive-name\fP
+is *, statistics will be printed for every archive.
+In the print-stats and d modes,
+\fB\-f\fP \fIarchive-name\fP
+can be specified multiple times, in which case the operation
+(printing statistics, or deletion) will be performed for each
+of the specified archives.
+.PP
+Note that each archive created must have a different name; consequently
+many users find it useful to include timestamps in archive names when
+repeatedly creating archives from the same files/directories (e.g.,
+daily backups).
+.PP
+As a special case, if used with
+\fB\--list-archives\fP -hashes
+then
+\fB\-f\fP
+indicates a
+\fItapehash\fP
+instead of an
+\fIarchive-name\fP,
+and will print metadata about the specified archive(s).
+This combination of options is intended for the GUI and is not needed for
+command-line usage.
+Po \fB\-f\fP
+cannot be used with
+\fB\--list-archives\fP
+if it does not also include
+\fB\--hashes\fP.
+Pc
+.TP
+\fB\--force-resources\fP
+Force the decryption of a passphrase-encrypted key file to proceed
+even if it is anticipated to require an excessive amount of memory
+or CPU time.
+.TP
+\fB\-H\fP
+(c mode only)
+Symbolic links named on the command line will be followed; the
+target of the link will be archived, not the link itself.
+.TP
+\fB\-h\fP
+(c mode only)
+Synonym for
+\fB\-L\fP.
+.TP
+\fB\--hashes\fP
+(list-archives mode only)
+Print hashes of archive names.
+If the
+\fB\-v\fP
+flag is specified one or more times, print the archive name as well.
+.PP
+This option is intended for the GUI and is not needed for command-line usage.
+.TP
+\fB\--humanize-numbers\fP
+Use SI prefixes to make numbers printed by
+\fB\--print-stats\fP
+and SIGINFO more readable.
+.TP
+\fB\-I\fP
+Synonym for
+\fB\-T\fP.
+.TP
+\fB\--include\fP \fIpattern\fP
+(c, x, and t modes only)
+Process only files or directories that match the specified pattern.
+Note that exclusions specified with
+\fB\--exclude\fP
+take precedence over inclusions.
+If no inclusions are explicitly specified, all entries are processed by
+default.
+The
+\fB\--include\fP
+option is especially useful when filtering archives.
+For example, the command
+.RS 4
+\fB\%tarsnap\fP \fB\-c\fP \fB\-f\fP \fIfoo-backup\fP \fB\--include='*foo*'\fP \fB@@\fP\fIall-backup\fP
+.RE
+creates a new archive
+\fIfoo-backup\fP
+containing only the entries from
+\fIall-backup\fP
+containing the string
+`foo'.
+.TP
+\fB\--insane-filesystems\fP
+(c mode only)
+Allow descent into synthetic filesystems such as procfs.
+Normally archiving of such filesystems is a silly thing to do, hence the
+name of the option.
+.TP
+\fB\--iso-dates\fP
+(t mode only)
+Print file and directory dates as yyyy-mm-dd hh:mm:ss.
+.PP
+The default is to use the same format as 'ls -l': If the files were modified
+within the past six months, print the month, day, hour, and minutes; otherwise,
+print the month, day, and year.
+.TP
+\fB\-k\fP
+(x mode only)
+Do not overwrite existing files.
+In particular, if a file appears more than once in an archive,
+later copies will not overwrite earlier copies.
+.TP
+\fB\--keep-going\fP
+(d and print-stats modes only)
+Continue deleting or printing statistics after finding that one
+of the archives specified does not exist.
+.TP
+\fB\--keep-newer-files\fP
+(x mode only)
+Do not overwrite existing files that are newer than the
+versions appearing in the archive being extracted.
+.TP
+\fB\--keyfile\fP \fIkey-file\fP
+(all modes)
+Obtain encryption, authentication, and access keys from
+\fIkey-file\fP.
+This file should have been generated by
+\fBtarsnap-keygen\fP(1).
+.TP
+\fB\-L\fP
+(c mode only)
+All symbolic links will be followed.
+Normally, symbolic links are archived as such.
+With this option, the target of the link will be archived instead.
+.TP
+\fB\-l\fP
+This is a synonym for the
+\fB\--check-links\fP
+option.
+.TP
+\fB\--lowmem\fP
+(c mode only)
+Reduce memory usage by not caching small files.
+This may be useful when backing up files of average size less
+than 1 MB if the available RAM in kilobytes is less than the
+number of files being backed up.
+.TP
+\fB\-m\fP
+(x mode only)
+Do not extract modification time.
+By default, the modification time is set to the time stored in the archive.
+.TP
+\fB\--maxbw\fP \fInumbytes\fP
+(c mode only)
+Interrupt archival if more than
+\fInumbytes\fP
+bytes of upstream bandwidth is used (see INTERRUPTING ARCHIVAL
+below for details).
+.TP
+\fB\--maxbw-rate\fP \fIbytespersecond\fP
+Limit download and upload bandwidth used to
+\fIbytespersecond\fP
+bytes per second.
+.TP
+\fB\--maxbw-rate-down\fP \fIbytespersecond\fP
+Limit download bandwidth used to
+\fIbytespersecond\fP
+bytes per second.
+.TP
+\fB\--maxbw-rate-up\fP \fIbytespersecond\fP
+Limit upload bandwidth used to
+\fIbytespersecond\fP
+bytes per second.
+.TP
+\fB\-n\fP
+(c mode only)
+Do not recursively archive the contents of directories.
+.TP
+\fB\--newer\fP \fIdate\fP
+(c, x, t modes only)
+Only include files and directories newer than the specified date.
+This compares ctime entries.
+.TP
+\fB\--newer-mtime\fP \fIdate\fP
+(c mode only)
+Like
+\fB\--newer\fP,
+except it compares mtime entries instead of ctime entries.
+.TP
+\fB\--newer-than\fP \fIfilename\fP
+(c mode only)
+Only include files and directories newer than the specified file.
+This compares ctime entries.
+.TP
+\fB\--newer-mtime-than\fP \fIfilename\fP
+(c mode only)
+Like
+\fB\--newer-than\fP,
+except it compares mtime entries instead of ctime entries.
+.TP
+\fB\--no-aggressive-networking\fP
+Ignore any
+\fBaggressive-networking\fP
+option specified in a configuration file.
+.TP
+\fB\--no-config-exclude\fP
+Ignore any
+\fBexclude\fP
+option specified in a configuration file.
+Normally
+\fBexclude\fP
+options specified via configuration files and the command line
+all take effect.
+.TP
+\fB\--no-config-include\fP
+Ignore any
+\fBinclude\fP
+option specified in a configuration file.
+Normally
+\fBinclude\fP
+options specified via configuration files and the command line
+all take effect.
+.TP
+\fB\--no-default-config\fP
+Do not read the default configuration files
+\fI/usr/local/etc/tarsnap.conf\fP,
+\fI$XDG_CONFIG_HOME/tarsnap/tarsnap.conf\fP,
+and
+\fI~/.tarsnaprc\fP.
+.TP
+\fB\--no-disk-pause\fP
+Ignore any
+\fBdisk-pause\fP
+option specified in a configuration file.
+.TP
+\fB\--no-force-resources\fP
+Ignore any
+\fBforce-resources\fP
+option specified in a configuration file.
+.TP
+\fB\--no-humanize-numbers\fP
+Ignore any
+\fBhumanize-numbers\fP
+option specified in a configuration file.
+.TP
+\fB\--no-insane-filesystems\fP
+Ignore any
+\fBinsane-filesystems\fP
+option specified in a configuration file.
+.TP
+\fB\--no-iso-dates\fP
+Ignore any
+\fBiso-dates\fP
+option specified in a configuration file.
+.TP
+\fB\--no-maxbw\fP
+Ignore any
+\fBmaxbw\fP
+option specified in a configuration file.
+.TP
+\fB\--no-maxbw-rate-down\fP
+Ignore any
+\fBmaxbw-rate-down\fP
+option specified in a configuration file.
+If a
+\fBmaxbw-rate\fP
+option is specified in a configuration file, it will
+not affect the download bandwidth used, but may affect
+the upload bandwidth used (unless
+\fB\--no-maxbw-rate-up\fP
+is also specified).
+.TP
+\fB\--no-maxbw-rate-up\fP
+Ignore any
+\fBmaxbw-rate-up\fP
+option specified in a configuration file.
+If a
+\fBmaxbw-rate\fP
+option is specified in a configuration file, it will
+not affect the upload bandwidth used, but may affect
+the download bandwidth used (unless
+\fB\--no-maxbw-rate-down\fP
+is also specified).
+.TP
+\fB\--no-noatime\fP
+Ignore any
+\fBnoatime\fP
+option specified in a configuration file.
+.TP
+\fB\--no-nodump\fP
+Ignore any
+\fBnodump\fP
+option specified in a configuration file.
+.TP
+\fB\--no-print-stats\fP
+Ignore any
+\fBprint-stats\fP
+option specified in a configuration file.
+.TP
+\fB\--no-progress-bytes\fP
+Ignore any
+\fBprogress-bytes\fP
+option specified in a configuration file.
+.TP
+\fB\--no-quiet\fP
+Ignore any
+\fBquiet\fP
+option specified in a configuration file.
+.TP
+\fB\--no-retry-forever\fP
+Ignore any
+\fBretry-forever\fP
+option specified in a configuration file.
+.TP
+\fB\--no-snaptime\fP
+Ignore any
+\fBsnaptime\fP
+option specified in a configuration file.
+.TP
+\fB\--no-store-atime\fP
+Ignore any
+\fBstore-atime\fP
+option specified in a configuration file.
+.TP
+\fB\--no-totals\fP
+Ignore any
+\fBtotals\fP
+option specified in a configuration file.
+.TP
+\fB\--noatime\fP
+(c mode only)
+Ask the operating system to not update the atime when reading files or
+directories.  Not supported by all operating systems and filesystems.
+.TP
+\fB\--nodump\fP
+(c mode only)
+Honor the nodump file flag by skipping this file or directory.
+.TP
+\fB\--noisy-warnings\fP
+Be verbose when warning about network glitches.
+This is probably only useful for debugging purposes.
+.TP
+\fB\--normalmem\fP
+Ignore any
+\fBlowmem\fP
+or
+\fBverylowmem\fP
+option specified in a configuration file.
+.TP
+\fB\--null\fP
+(use with
+\fB\-I\fP,
+\fB\-T\fP,
+or
+\fB\-X\fP)
+Synonym for
+\fB\--null-input\fP.
+Kept for historical reasons and compatibility with other tar utilities.
+.TP
+\fB\--null-input\fP
+(use with
+\fB\-I\fP,
+\fB\-T\fP,
+or
+\fB\-X\fP)
+Filenames, archive names, and patterns are separated by null characters,
+not by newlines.
+This is often used to read filenames output by the
+\fB\-print0\fP
+option to
+\fBfind\fP(1).
+.TP
+\fB\--null-output\fP
+(x, t, list-archives, and print-stats modes only)
+Archive names, filenames, and lines in output are separated by null
+characters, not by newlines.
+.PP
+If there are multiple fields on a line, they will be separated by two null
+characters.
+If a command line is printed within one of those fields, each argument will be
+separated by three null characters.
+.TP
+\fB\--numeric-owner\fP
+(x mode only)
+Ignore symbolic user and group names when restoring archives to disk,
+only numeric uid and gid values will be obeyed.
+.TP
+\fB\-O\fP
+(x and t modes only)
+In extract (-x) mode, files will be written to standard out rather than
+being extracted to disk.
+In list (-t) mode, the file listing will be written to stderr rather than
+the usual stdout.
+.TP
+\fB\-o\fP
+(x mode only)
+Use the user and group of the user running the program rather
+than those specified in the archive.
+Note that this has no significance unless
+\fB\-p\fP
+is specified, and the program is being run by the root user.
+In this case, the file modes and flags from
+the archive will be restored, but ACLs or owner information in
+the archive will be discarded.
+.TP
+\fB\--one-file-system\fP
+(c mode only)
+Do not cross mount points.
+.TP
+\fB\-P\fP
+(c, x, and t modes only)
+Preserve pathnames.
+By default, absolute pathnames (those that begin with a /
+character) have the leading slash removed both when creating archives
+and extracting from them.
+Also,
+\fB\%tarsnap\fP
+will refuse to extract archive entries whose pathnames contain
+\fI\& ..\fP
+or whose target directory would be altered by a symlink.
+This option suppresses these behaviors.
+.TP
+\fB\-p\fP
+(x mode only)
+Preserve file permissions.
+Attempt to restore the full permissions, including owner, file modes, file
+flags and ACLs, if available, for each item extracted from the archive.
+By default, newly-created files are owned by the user running
+\fB\%tarsnap\fP,
+the file mode is restored for newly-created regular files, and
+all other types of entries receive default permissions.
+If
+\fB\%tarsnap\fP
+is being run by root, the default is to restore the owner unless the
+\fB\-o\fP
+option is also specified.
+.TP
+\fB\--passphrase\fP \fImethod:arg\fP
+Read the passphrase using the specified method.
+.RS 5
+.TP
+\fIdev:tty-stdin\fP
+Attempt to read the passphrase from /dev/tty; if that fails, read it from stdin.
+This is the default behaviour.
+.TP
+\fIdev:stdin-once\fP
+Attempt to read the passphrase from stdin, and do so only once even when
+encrypting.
+This cannot be used if
+\fIinfile\fP
+is also stdin (aka '-').
+.TP
+\fIdev:tty-once\fP
+Attempt to read the passphrase from /dev/tty, and do so only once
+even when encrypting.
+.TP
+\fIenv:VAR\fP
+Read the passphrase from the environment variable specified by
+\fIVAR\fP.
+.PP
+Bf .IR
+Storing a passphrase in an environment variable may be a security risk.
+Ef
+Only use this option if you are certain that you know what you are doing.
+.TP
+\fIfile:FILENAME\fP
+Read the passphrase from the file specified by
+\fIFILENAME\fP.
+.PP
+Bf .IR
+Storing a passphrase in a file may be a security risk.
+Ef
+Only use this option if you are certain that you know what you are doing.
+.RE
+.TP
+\fB\--print-stats\fP
+(c and d modes only)
+Print statistics for the archive being created (c mode) or delete (d mode).
+See "PRINTING ARCHIVE STATISTICS" below for information on the output format.
+.TP
+\fB\--progress-bytes\fP \fIX\fP
+Display a progress message (as if generated from SIGUSR1 or SIGINFO) after
+processing each
+\fIX\fP
+bytes.
+Occurs at most once per file.
+.TP
+\fB\-q\fP (\fB\--fast-read\fP)
+(x and t modes only)
+Extract or list only the first archive entry that matches each pattern
+or filename operand.
+Exit as soon as each specified pattern or filename has been matched.
+By default, the archive is always read to the very end, since
+there can be multiple entries with the same name and, by convention,
+later entries overwrite earlier entries.
+This option is provided as a performance optimization.
+.TP
+\fB\--quiet\fP
+Avoid printing some warnings.
+Currently the warnings which are silenced by this option are
+"Removing leading '/' ...",
+"Not adding cache directory to archive",
+"... file may have grown while being archived",
+and
+"Skipping entry on filesystem of type ...",
+but it is likely that other
+warnings will be silenced by this option in future versions of
+\fB\%tarsnap\fP.
+.TP
+\fB\--resume-extract\fP
+(x mode only)
+Don't extract files whose filesize and mtime matches existing files on the
+disk.
+Primarily used to resume an archive extraction which was interrupted.
+The mtime comparison ignores sub-second timestamp precision, as this is not
+supported on all filesystems.
+This differs from
+\fB\-k\fP
+in that
+\fB\--resume-extract\fP
+will overwrite a file if the size or modification time do not match, as can
+happen if tarsnap is killed partway through extracting a file.
+.TP
+\fB\--retry-forever\fP
+This option causes tarsnap to continue trying to reconnect to the
+tarsnap server forever, instead of giving up after 5-10 minutes.
+This may be useful for people with excessively flaky networks, or
+on mobile devices which regularly lose their internet connections
+for extended periods of time.
+This is not enabled by default since continued failures generally indicate a
+problem which should be investigated by the user.
+.TP
+\fB\-S\fP
+(x mode only)
+Extract files as sparse files.
+For every block on disk, check first if it contains any non-NULL bytes and seek
+over it otherwise.
+This works similar to the conv=sparse option of dd.
+.TP
+\fB\-s\fP \fIpattern\fP
+Modify file or archive member names according to
+\fIpattern\fP.
+The pattern has the format /old/new/[gps].
+old is a basic regular expression.
+If it doesn't apply, the pattern is skipped.
+new is the replacement string of the matched part.
+~ is substituted with the match, \e1 to \e9 with the contents of
+the corresponding captured group.
+The optional trailing g specifies that matching should continue
+after the matched part and stop on the first unmatched pattern.
+The optional trailing s specifies that the pattern applies to the value
+of symbolic links.
+The optional trailing p specifies that after a successful substitution
+the original path name and the new path name should be printed to
+standard error.
+.TP
+\fB\--snaptime\fP \fIfilename\fP
+(c mode only)
+This option MUST be specified when creating a backup from a filesystem
+snapshot, and
+\fIfilename\fP
+must have a modification time prior to when the filesystem snapshot was
+created.
+(This is necessary to prevent races between file modification and snapshot
+creation which could result in
+\fB\%tarsnap\fP
+failing to recognize that a file has been modified.)
+.TP
+\fB\--store-atime\fP
+(c mode only)
+Enable the storing of file access times.
+The default behaviour of
+\fB\%tarsnap\fP
+is to not store file access times, since this can cause a significant amount
+of bandwidth and storage to be wasted when the same set of files are archived
+several times (e.g., if daily backup archives are created) due to
+\fB\%tarsnap\fP
+itself accessing files and thereby causing their access times to be changed.
+.TP
+\fB\--strip-components\fP \fIcount\fP
+(x mode only)
+Remove the specified number of leading path elements.
+Pathnames with fewer elements will be silently skipped.
+Note that the pathname is edited after checking inclusion/exclusion patterns
+but before security checks.
+.TP
+\fB\-T\fP \fIfilename\fP
+(c, x, and t modes only)
+In x or t mode,
+\fB\%tarsnap\fP
+will read the list of names to be extracted from
+\fIfilename\fP.
+In c mode,
+\fB\%tarsnap\fP
+will read names to be archived from
+\fIfilename\fP.
+The special name
+``-C''
+on a line by itself will cause the current directory to be changed to
+the directory specified on the following line.
+Names are terminated by newlines unless
+\fB\--null-input\fP
+is specified.
+Note that
+\fB\--null-input\fP
+also disables the special handling of lines containing
+``-C''.
+If
+\fIfilename\fP
+is
+``-''
+then the list of names will be read from the standard input.
+Note:  If you are generating lists of files using
+\fBfind\fP(1),
+you probably want to use
+\fB\-n\fP
+as well.
+.TP
+\fB\--totals\fP
+(c mode only)
+Print the size of the archive after creating it.
+This option is provided mainly for compatibility with GNU tar; in most
+situations the
+\fB\--print-stats\fP
+option will be far more useful.
+.TP
+\fB\-U\fP
+(x mode only)
+Unlink files before creating them.
+Without this option,
+\fB\%tarsnap\fP
+overwrites existing files, which preserves existing hardlinks.
+With this option, existing hardlinks will be broken, as will any
+symlink that would affect the location of an extracted file.
+.TP
+\fB\-v\fP
+(c, d, t, x, and list-archives modes only)
+Produce verbose output.
+In create and extract modes,
+\fB\%tarsnap\fP
+will list each file name as it is read from or written to
+the archive.
+In delete mode,
+\fB\%tarsnap\fP
+will list the name of each archive as it is deleted.
+In list mode,
+\fB\%tarsnap\fP
+will produce output similar to that of
+\fBls\fP(1).
+Additional
+\fB\-v\fP
+options will provide additional detail.
+.TP
+\fB\--verify-config\fP
+Check the configuration file(s) for syntactic errors.
+.TP
+\fB\--version\fP
+Print version number of
+\fB\%tarsnap\fP,
+and exit.
+.TP
+\fB\--verylowmem\fP
+(c mode only)
+Reduce memory usage, by approximately a factor of 2 beyond
+the memory usage when
+\fB\--lowmem\fP
+is specified, by not caching anything.
+.TP
+\fB\-w\fP
+(c and x modes only)
+Ask for confirmation for every action.
+.TP
+\fB\-X\fP \fIfilename\fP
+(c, x, and t modes only)
+Read a list of exclusion patterns from the specified file.
+See
+\fB\--exclude\fP
+for more information about the handling of exclusions.
+.RE
+.SH SIGNALS
+.ad l
+\fB\%tarsnap\fP
+handles the following signals:
+.RS 5
+.TP
+SIGUSR1 & SIGINFO
+On receipt of the SIGUSR1 signal or (on platforms where it exists) the
+SIGINFO signal,
+\fB\%tarsnap\fP
+prints the current file or directory being processed, and (for files)
+its progress within the file.
+It also prints the number of files and the number of uncompressed bytes
+processed.
+Note that due to network buffering the file position will not align precisely
+with how much data has been sent to or received from the
+\fB\%tarsnap\fP
+server.
+.TP
+SIGSTOP & SIGTSTP
+On receipt of a SIGSTOP or SIGTSTP signal, the kernel will suspend the
+\fB\%tarsnap\fP
+process.
+Upon receiving a SIGCONT signal,
+\fB\%tarsnap\fP
+will reconnect to the server (if necessary) and continue the specified task.
+.TP
+SIGUSR2
+On receipt of the SIGUSR2 signal, if
+\fB\%tarsnap\fP
+is creating an archive (mode c), it will create a checkpoint at the
+current position.
+.TP
+SIGQUIT
+On receipt of the SIGQUIT signal, if
+\fB\%tarsnap\fP
+is creating an archive (mode c) it will truncate the archive at the
+current position and exit (see "INTERRUPTING ARCHIVAL" below).
+.RE
+.SH PRINTING ARCHIVE STATISTICS
+.ad l
+There are four commands which print statistics about archives:
+.RS 5
+.IP \(bu
+Global statistics:
+.RS 4
+\fB\%tarsnap\fP \fB\--print-stats\fP
+.RE
+.IP \(bu
+Global statistics and info about specific archive(s):
+.RS 4
+\fB\%tarsnap\fP \fB\--print-stats\fP \fB\-f\fP \fIarchive-name1\fP [\fB\-f\fP \fI...\fP]
+.RE
+.IP \(bu
+Global statistics and info about all archives:
+.RS 4
+\fB\%tarsnap\fP \fB\--print-stats\fP \fB\-f\fP \fI'*'\fP
+.RE
+.IP \(bu
+Global statistics and info about the archive(s) that were just created or
+deleted:
+.RS 4
+\fB\%tarsnap\fP \fB\-c\fP \fB\--print-stats\fP \fB\-f\fP \fIarchive-name\fP \fIDIR\fP
+.RE
+.RS 4
+\fB\%tarsnap\fP \fB\-d\fP \fB\--print-stats\fP \fB\-f\fP \fIarchive-name1\fP [\fB\-f\fP \fI...\fP]
+.RE
+.RE
+.PP
+\fB\%tarsnap\fP
+will print a table in the following format:
+.RS 4
+.nf
+                                       Total size  Compressed size
+All archives                         104491640436      51510524844
+  (unique data)                       14830618089       7733620463
+This archive                            808723344        289077325
+New data                                 17858641          5658308
+.RE
+.PP
+In this example, the combined size of all archives stored by
+\fB\%tarsnap\fP
+using the same keys is 104 GB, and the combined size post-compression
+would be 51 GB; but after removing duplicate blocks, there is only 14.8 GB
+which is compressed down to 7.7 GB.
+(It is this 7.7 GB which is stored via the Tarsnap service and must
+thus be paid for.)
+The newly created archive is 808 MB in size (compressible to 289 MB), but
+only 17.8 MB of the data is new, and after compression only 5.6 MB is
+uploaded to the Tarsnap server.
+.PP
+When
+\fB\%tarsnap\fP
+\fB\--print-stats\fP
+is executed as a command, the table is printed to the standard output;
+when the
+\fB\--print-stats\fP
+option is used while creating or deleting archives, the table is printed
+to the standard error device.
+.PP
+Global statistics are calculated based on the current cache directory, without
+using the keyfile or querying the Tarsnap servers.
+.SH INTERRUPTING ARCHIVAL
+.ad l
+Upon receipt of the
+.BR SIGQUIT
+signal or \&^Q,
+or if the bandwidth limit specified via a
+\fB\--maxbw\fP
+option is reached,
+\fB\%tarsnap\fP
+will interrupt the creation of an archive and truncate it
+at the current position.
+When an archive is truncated, it will be named according to
+the user-specified name plus ".part" to denote the fact that
+it is incomplete.
+Such a truncated archive may be useful in its own right, but
+also offers the benefit that future attempts to archive the
+same data will be faster and use less bandwidth.
+.SH FIREWALLS
+.ad l
+\fB\%tarsnap\fP
+communicates with the
+\fB\%tarsnap\fP
+server via a TCP connection to port 9279; in some environments
+it may be necessary to add a firewall rule to allow outgoing
+TCP connections to this port.
+At the present time (July 2009) there is only one IP address in
+use for the
+\fB\%tarsnap\fP
+server, so network administrators may wish to hard-code that IP
+address; however, it is likely that at some point in the future
+that IP address will change and/or other IP addresses will be
+added.
+.SH ENVIRONMENT
+.ad l
+The following environment variables affect the execution of
+\fB\%tarsnap\fP:
+.RS 5
+.TP
+.B LANG
+The locale to use.
+See
+\fBenviron\fP(7)
+for more information.
+.TP
+.B TZ
+The timezone to use when displaying dates.
+See
+\fBenviron\fP(7)
+for more information.
+.RE
+.SH FILES
+.ad l
+.RS 5
+.TP
+.B /usr/local/etc/tarsnap.conf
+The system global
+\fB\%tarsnap\fP
+configuration file.
+Parameters specified here only take effect if they are not
+specified via the current user's local configuration file
+or via the command line.
+.TP
+.B $XDG_CONFIG_HOME/tarsnap/tarsnap.conf
+A
+\fB\%tarsnap\fP
+configuration file for the current user.
+If the environment variable
+.IR XDG_CONFIG_HOME
+is empty, the default value of
+\fI~/.config/tarsnap/tarsnap.conf\fP
+will be used.
+Parameters specified here take effect unless they are specified via
+\fI~/.tarsnaprc\fP
+or the command line.
+.TP
+.B ~/.tarsnaprc
+Another location for the
+\fB\%tarsnap\fP
+configuration file for the current user.
+Parameters specified here take effect unless they are
+specified via the command line.
+.RE
+.SH EXIT STATUS
+.ad l
+The \fBtarsnap\fP utility exits 0 on success, and >0 if an error occurs.
+.PP
+An exit code of 2 indicates that an error has occurred and the server-side
+state was modified.
+.SH EXAMPLES
+.ad l
+Register with the server and generate keys:
+.RS 4
+\fB\%tarsnap-keygen\fP \fB\--keyfile\fP \fI/usr/tarsnap.key\fP \fB\--user\fP \fIme@example.com\fP \fB\--machine\fP \fImyserver\fP
+.RE
+.PP
+Perform a backup of
+\fI/usr/home\fP
+and
+\fI/other/stuff/to/backup\fP:
+.RS 4
+\fB\%tarsnap\fP \fB\--keyfile\fP \fI/usr/tarsnap.key\fP \fB\--cachedir\fP \fI/usr/tarsnap-cache\fP \fB\-c\fP \fB\-f\fP \fIbackup-2008-04-24\fP \fI/usr/home\fP \fI/other/stuff/to/backup\fP
+.RE
+.PP
+Perform another backup, a day later;
+this is much faster since tarsnap will avoid
+storing data which was previously stored:
+.RS 4
+\fB\%tarsnap\fP \fB\--keyfile\fP \fI/usr/tarsnap.key\fP \fB\--cachedir\fP \fI/usr/tarsnap-cache\fP \fB\-c\fP \fB\-f\fP \fIbackup-2008-04-25\fP \fI/usr/home\fP \fI/other/stuff/to/backup\fP
+.RE
+.PP
+List the archives:
+.RS 4
+\fB\%tarsnap\fP \fB\--keyfile\fP \fI/usr/tarsnap.key\fP \fB\--list-archives\fP
+.RE
+.PP
+Delete the first backup, leaving the second backup intact:
+.RS 4
+\fB\%tarsnap\fP \fB\--keyfile\fP \fI/usr/tarsnap.key\fP \fB\--cachedir\fP \fI/usr/tarsnap-cache\fP \fB\-d\fP \fB\-f\fP \fIbackup-2008-04-24\fP
+.RE
+.PP
+List the files in the remaining backup:
+.RS 4
+\fB\%tarsnap\fP \fB\--keyfile\fP \fI/usr/tarsnap.key\fP \fB\-tv\fP \fB\-f\fP \fIbackup-2008-04-25\fP
+.RE
+.PP
+Restore two users' home directories from the backup:
+.RS 4
+\fB\%tarsnap\fP \fB\--keyfile\fP \fI/usr/tarsnap.key\fP \fB\-x\fP \fB\-f\fP \fIbackup-2008-04-25\fP \fIusr/home/auser\fP \fIusr/home/anotheruser\fP
+.RE
+.PP
+In
+\fI/etc/crontab\fP
+to create a backup of the entire system at 10:32 each day:
+.RS 4
+32 10 * * * root \fB\%tarsnap\fP \fB\--keyfile\fP \fI/usr/tarsnap.key\fP \fB\--cachedir\fP \fI/usr/tarsnap-cache\fP \fB\-c\fP \fB\-f\fP \fIbackup-`date\fP +\e%Y\e%m\e%d` \fI/\fP
+.RE
+.PP
+Note that the
+\fB\--keyfile\fP
+and
+\fB\--cachedir\fP
+options can be specified via the
+\fBtarsnap.conf\fP(5)
+configuration file, in which case they may be omitted
+from the command line.
+.SH SECURITY
+.ad l
+Certain security issues are common to many archiving programs, including
+\fB\%tarsnap\fP.
+In particular, carefully-crafted archives can request that
+\fB\%tarsnap\fP
+extract files to locations outside of the target directory.
+This can potentially be used to cause unwitting users to overwrite
+files they did not intend to overwrite.
+If the archive is being extracted by the superuser, any file
+on the system can potentially be overwritten.
+There are three ways this can happen.
+Although
+\fB\%tarsnap\fP
+has mechanisms to protect against each one,
+savvy users should be aware of the implications:
+.RS 5
+.IP \(bu
+Archive entries can have absolute pathnames.
+By default,
+\fB\%tarsnap\fP
+removes the leading
+\fI/\fP
+character from filenames before restoring them to guard against this problem.
+.IP \(bu
+Archive entries can have pathnames that include
+\fI\& ..\fP
+components.
+By default,
+\fB\%tarsnap\fP
+will not extract files containing
+\fI\& ..\fP
+components in their pathname.
+.IP \(bu
+Archive entries can exploit symbolic links to restore
+files to other directories.
+An archive can restore a symbolic link to another directory,
+then use that link to restore a file into that directory.
+To guard against this,
+\fB\%tarsnap\fP
+checks each extracted path for symlinks.
+If the final path element is a symlink, it will be removed
+and replaced with the archive entry.
+If
+\fB\-U\fP
+is specified, any intermediate symlink will also be unconditionally removed.
+If neither
+\fB\-U\fP
+nor
+\fB\-P\fP
+is specified,
+\fB\%tarsnap\fP
+will refuse to extract the entry.
+.RE
+.PP
+Although
+\fB\%tarsnap\fP
+cryptographically signs archives in such a manner that it is believed
+to be unfeasible for an attacker to forge an archive without having
+possession of
+\fIkey-file\fP,
+you may wish to examine the contents of archive(s) with
+.RS 4
+\fB\%tarsnap\fP \fB\-t\fP \fB\--keyfile\fP \fIkey-file\fP \fB\-f\fP \fIarchive-name\fP
+.RE
+before extraction.
+Note that the
+\fB\-P\fP
+option to
+\fB\%tarsnap\fP
+disables the security checks above and allows you to extract
+an archive while preserving any absolute pathnames,
+\fI\& ..\fP
+components, or symlinks to other directories.
+.SH SEE ALSO
+.ad l
+\fBtarsnap-keygen\fP(1),
+\fBtar\fP(5),
+\fBtarsnap.conf\fP(5)
+.SH HISTORY
+.ad l
+A
+\fB\%tar\fP
+command appeared in Seventh Edition Unix, which was
+released in January, 1979.
+There have been numerous other implementations,
+many of which extended the file format.
+John Gilmore's
+\fB\%pdtar\fP
+public-domain implementation (circa November, 1987)
+was quite influential, and formed the basis of GNU tar.
+GNU tar was included as the standard system tar
+in
+FreeBSD
+beginning with
+FreeBSD 1.0,
+but was replaced by Tim Kientzle's
+\fB\%bsdtar\fP
+utility and
+\fBlibarchive\fP(3)
+library in
+FreeBSD 5.3.
+.PP
+\fB\%tarsnap\fP
+is built around
+\fB\%bsdtar\fP
+and
+\fBlibarchive\fP(3).
+.SH BUGS
+.ad l
+This program follows
+ISO/IEC 9945-1:1996 (``POSIX.1'')
+for the definition of the
+\fB\-l\fP
+option to
+\fBtar\fP(5).
+Note that GNU tar prior to version 1.15 treated
+\fB\-l\fP
+as a synonym for the
+\fB\--one-file-system\fP
+option.
+.PP
+To archive a file called
+\fI@foo\fP,
+\fI@@foo\fP,
+or
+\fI-foo\fP
+you must specify it as
+\fI\& ./@foo\fP,
+\fI\& ./@@foo\fP,
+or
+\fI\& ./-foo\fP,
+respectively.
+.PP
+In create mode, a leading
+\fI\& ./\fP
+is always removed.
+A leading
+\fI/\fP
+is stripped unless the
+\fB\-P\fP
+option is specified.
+.PP
+Hard link information may be lost if an archive file which is included via the
+\fB@\fP\fIarchive-file\fP
+option is in a non-"tar" format.
+(This is a consequence of the incompatible ways that different archive
+formats store hardlink information.)
+.PP
+There are alternative long options for many of the short options that
+are deliberately not documented.
+.PP
+The limit specified by a
+\fB\--maxbw\fP
+option is not strictly enforced;
+in particular, due to the need to cleanly terminate an archive, the
+amount of bandwidth used may slightly exceed the limit.
+.PP
+If
+\fB\%tarsnap\fP
+is run with standard input, standard output, and standard error
+redirected and inside a chroot where terminal devices are not
+exposed, \&^Q will not be mapped to SIGQUIT and will consequently not
+trigger the truncation of the current archive.

--- a/tar/tarsnap.conf.5-man
+++ b/tar/tarsnap.conf.5-man
@@ -1,0 +1,174 @@
+.TH TARSNAP.CONF 5 "@DATE@" ""
+.SH NAME
+.ad l
+\fB\%tarsnap.conf\fP
+\- configuration file for
+\fBtarsnap\fP(1)
+.SH DESCRIPTION
+.ad l
+The
+\fB\%tarsnap.conf\fP
+file is read by the
+\fBtarsnap\fP(1)
+utility and specifies default options which will be
+ignored if the options in question are specified at
+the command line.
+Options may be specified in
+\fI/usr/local/etc/tarsnap.conf\fP,
+\fI$XDG_CONFIG_HOME/tarsnap/tarsnap.conf\fP,
+and/or
+\fI~/.tarsnaprc\fP;
+if those files conflict, the file listed last takes precedence.
+.PP
+The
+\fB\%tarsnap.conf\fP
+file(s) contain lines consisting of a case-sensitive option name and
+zero or one parameters depending upon the option.
+Empty lines and lines starting with a
+Ql #
+character are ignored.
+.PP
+If a parameter begins with a
+Ql ~
+character, it will be replaced by the home directory of the effective user ID.
+.PP
+The following options may be specified:
+.RS 5
+.TP
+\fBaggressive-networking\fP
+.TP
+\fBcachedir\fP \fIcache-dir\fP
+.TP
+\fBcheckpoint-bytes\fP \fIbytespercheckpoint\fP
+.TP
+\fBdisk-pause\fP \fIX\fP
+.TP
+\fBexclude\fP \fIpattern\fP
+.TP
+\fBforce-resources\fP
+.TP
+\fBhumanize-numbers\fP
+.TP
+\fBinclude\fP \fIpattern\fP
+.TP
+\fBinsane-filesystems\fP
+.TP
+\fBiso-dates\fP
+.TP
+\fBkeyfile\fP \fIkey-file\fP
+.TP
+\fBlowmem\fP
+.TP
+\fBmaxbw\fP
+.TP
+\fBmaxbw-rate\fP
+.TP
+\fBmaxbw-rate-down\fP
+.TP
+\fBmaxbw-rate-up\fP
+.TP
+\fBnodump\fP
+.TP
+\fBnormalmem\fP
+.TP
+\fBno-aggressive-networking\fP
+.TP
+\fBno-config-exclude\fP
+.TP
+\fBno-config-include\fP
+.TP
+\fBno-disk-pause\fP
+.TP
+\fBno-force-resources\fP
+.TP
+\fBno-humanize-numbers\fP
+.TP
+\fBno-insane-filesystems\fP
+.TP
+\fBno-iso-dates\fP
+.TP
+\fBno-maxbw\fP
+.TP
+\fBno-maxbw-rate-down\fP
+.TP
+\fBno-maxbw-rate-up\fP
+.TP
+\fBno-nodump\fP
+.TP
+\fBno-print-stats\fP
+.TP
+\fBno-quiet\fP
+.TP
+\fBno-retry-forever\fP
+.TP
+\fBno-snaptime\fP
+.TP
+\fBno-store-atime\fP
+.TP
+\fBno-totals\fP
+.TP
+\fBprint-stats\fP
+.TP
+\fBquiet\fP
+.TP
+\fBretry-forever\fP
+.TP
+\fBsnaptime\fP \fIfile\fP
+.TP
+\fBstore-atime\fP
+.TP
+\fBtotals\fP
+.TP
+\fBverylowmem\fP
+.RE
+.PP
+Each option is handled the same way as the corresponding
+\fB\--option\fP;
+see
+\fBtarsnap\fP(1)
+for more details.
+Note that the
+\fBnormalmem\fP
+and
+\fBno-*\fP
+options are only useful in the user-specific
+\fI~/.tarsnaprc\fP
+configuration file, at which point they act to override options set in the
+global
+\fI/usr/local/etc/tarsnap.conf\fP
+configuration file.
+.SH FILES
+.ad l
+.RS 5
+.TP
+.B /usr/local/etc/tarsnap.conf
+The system global
+\fB\%tarsnap.conf\fP
+configuration file.
+Parameters specified here only take effect if they are not
+specified via the current user's local configuration file
+or via the per-user XDG configuration file or via the command line.
+.TP
+.B $XDG_CONFIG_HOME/tarsnap/tarsnap.conf
+The XDG per-user
+\fB\%tarsnap.conf\fP
+configuration file.
+If
+.IR XDG_CONFIG_HOME
+is unset,
+\fI~/.config/tarsnap/tarsnap.conf\fP
+is used instead.
+Parameters specified here take effect unless they are
+specified via the current user's local configuration file
+or via the command line.
+.TP
+.B ~/.tarsnaprc
+The
+\fB\%tarsnap.conf\fP
+configuration file for the current user.
+Parameters specified here take effect unless they are
+specified via the command line.
+.RE
+.SH SEE ALSO
+.ad l
+\fBtarsnap\fP(1)


### PR DESCRIPTION
Replace the overflow-prone addition in the AES-CTR pre-wholeblock boundary check with an equivalent subtraction comparison.
patch_sha256=22229fcc47a35e841d1285d414b46f95989fe21aee966204ed58bc6f770319b9