### PR TITLE
Fix exit status for unreadable files and check header append failure

### DIFF
--- a/tar/multitape/multitape_write.c
+++ b/tar/multitape/multitape_write.c
@@ -622,7 +622,8 @@ writetape_write(TAPE_W * d, const void * buffer, size_t nbytes)
 		/* FALLTHROUGH */
 	case 0:
 		/* We're in header mode.  Append the data to d->hbuf. */
-		bytebuf_append(d->hbuf, buffer, nbytes);
+		if (bytebuf_append(d->hbuf, buffer, nbytes))
+			goto err0;
 	}
 
 	/* Success! */

--- a/tar/write.c
+++ b/tar/write.c
@@ -1086,6 +1086,7 @@ write_entry_backend(struct bsdtar *bsdtar, struct archive *a,
 		fd = fileutil_open_noatime(pathname, O_RDONLY,
 		    bsdtar->option_noatime);
 		if (fd == -1) {
+			bsdtar->return_value = 1;
 			if (!bsdtar->verbose)
 				bsdtar_warnc(bsdtar, errno,
 				    "%s: could not open file", pathname);


### PR DESCRIPTION
This PR fixes two reported bugs:

1. **#772:** A file that cannot be opened is omitted from the backup, but now `bsdtar->return_value = 1` is properly set so the exit status indicates failure.
2. **#773:** `writetape_write()` now checks the return value of `bytebuf_append()` and correctly bails if it fails to prevent silent archive corruption.

Fixes #772
Fixes #773