### PR TITLE
Fix write_file_data read error and hmac dangling pointer

### DIFF
--- a/lib/crypto/crypto_keys_subr.c
+++ b/lib/crypto/crypto_keys_subr.c
@@ -518,6 +518,12 @@ err2:
 	free((*key)->key);
 err1:
 	free(*key);
+	/*
+	 * The caller's pointer is a slot in the static key cache, and
+	 * crypto_keys_atexit() will pass it to crypto_keys_subr_free_HMAC()
+	 * whatever we return, so it must not be left dangling.
+	 */
+	*key = NULL;
 err0:
 	/* Failure! */
 	return (-1);

--- a/tar/multitape/multitape_write.c
+++ b/tar/multitape/multitape_write.c
@@ -622,7 +622,8 @@ writetape_write(TAPE_W * d, const void * buffer, size_t nbytes)
 		/* FALLTHROUGH */
 	case 0:
 		/* We're in header mode.  Append the data to d->hbuf. */
-		bytebuf_append(d->hbuf, buffer, nbytes);
+		if (bytebuf_append(d->hbuf, buffer, nbytes))
+			goto err0;
 	}
 
 	/* Success! */

--- a/tar/write.c
+++ b/tar/write.c
@@ -1257,6 +1257,13 @@ write_file_data(struct bsdtar *bsdtar, struct archive *a,
 		progress += bytes_written;
 		bytes_read = read(fd, bsdtar->buff, FILEDATABUFLEN);
 	}
+
+	if (bytes_read < 0) {
+		bsdtar_warnc(bsdtar, errno, "%s: Read error",
+		    archive_entry_pathname(entry));
+		return (-1);
+	}
+
 	return 0;
 }
 

--- a/tar/write.c
+++ b/tar/write.c
@@ -1086,6 +1086,7 @@ write_entry_backend(struct bsdtar *bsdtar, struct archive *a,
 		fd = fileutil_open_noatime(pathname, O_RDONLY,
 		    bsdtar->option_noatime);
 		if (fd == -1) {
+			bsdtar->return_value = 1;
 			if (!bsdtar->verbose)
 				bsdtar_warnc(bsdtar, errno,
 				    "%s: could not open file", pathname);


### PR DESCRIPTION
This PR fixes two reported bugs:

1. **#769:** `crypto_keys_subr_generate_HMAC()` frees the cached key but previously left a dangling pointer. It now explicitly sets `*key = NULL` on the error path to avoid a double-free / heap-use-after-free crash during `atexit` cleanup.
2. **#771:** A read error (e.g. `EIO`) during `write_file_data()` would break the read loop but return 0 (success) and result in a zero-padded archive entry. We now check `bytes_read < 0` at the end of the loop and error out properly.

Fixes #769
Fixes #771