### PR TITLE
Fix getdate overflow and multitape stats use-after-free

### DIFF
--- a/tar/getdate.c
+++ b/tar/getdate.c
@@ -53,7 +53,7 @@ enum DSTMODE { DSTon, DSToff, DSTmaybe };
 enum { tAM, tPM };
 /* Token types returned by nexttoken() */
 enum { tAGO = 260, tDAY, tDAYZONE, tAMPM, tMONTH, tMONTH_UNIT, tSEC_UNIT,
-       tUNUMBER, tZONE, tDST };
+       tUNUMBER, tZONE, tDST, tERROR };
 struct token { int token; time_t value; };
 
 /*
@@ -867,9 +867,24 @@ nexttoken(char **in, time_t *value)
 		 * don't deal with signed numbers here.
 		 */
 		if (isdigit((unsigned char)(c = **in))) {
-			for (*value = 0; isdigit((unsigned char)(c = *(*in)++)); )
-				*value = 10 * *value + c - '0';
+			unsigned long long val = 0;
+			int overflow = 0;
+			unsigned long long tmax = ~0ULL;
+			if (sizeof(time_t) == 4)
+				tmax = ((time_t)-1 > 0) ? 0xFFFFFFFFULL : 0x7FFFFFFFULL;
+			else if (sizeof(time_t) == 8)
+				tmax = ((time_t)-1 > 0) ? 0xFFFFFFFFFFFFFFFFULL : 0x7FFFFFFFFFFFFFFFULL;
+
+			for (; isdigit((unsigned char)(c = *(*in)++)); ) {
+				if (val > (~0ULL - (c - '0')) / 10)
+					overflow = 1;
+				else
+					val = 10 * val + c - '0';
+			}
 			(*in)--;
+			if (overflow || val > tmax)
+				return (tERROR);
+			*value = (time_t)val;
 			return (tUNUMBER);
 		}
 

--- a/tar/multitape/multitape_stats.c
+++ b/tar/multitape/multitape_stats.c
@@ -236,6 +236,12 @@ statstape_printlist_item(TAPE_S * d, const uint8_t tapehash[32], int verbose,
 	char datebuf[DATEBUFLEN];
 	int arg;
 
+	/*
+	 * tmd is not filled in until multitape_metadata_get_byhash() below,
+	 * but the error path frees it; make that safe.
+	 */
+	memset(&tmd, 0, sizeof(tmd));
+
 	/* Print archive hash. */
 	if (print_hash) {
 		hexify(tapehash, hexstr, 32);


### PR DESCRIPTION
This PR fixes two reported bugs:

1. **#768:** In `tar/getdate.c`, the lexer could silently overflow a `long` when a user supplied an exceptionally long digit string (e.g. `--newer-mtime 18446744073709551616`). It now performs unsigned bounded arithmetic up to the limits of `time_t` and safely rejects overflowing values.
2. **#770:** In `tar/multitape/multitape_stats.c`, `statstape_printlist_item()` previously freed an uninitialized `tmd` structure if it encountered a write error (like a full disk or broken pipe) before loading the metadata. In loops, this reused stale stack pointers, causing a crash. It now correctly zero-initializes `tmd`.

Fixes #768
Fixes #770