### PR TITLE
Fix bugs #761, #766, #767

### DIFF
--- a/tar/ccache/ccache_entry.c
+++ b/tar/ccache/ccache_entry.c
@@ -326,10 +326,10 @@ ccache_entry_lookup(CCACHE * cache, const char * path, const struct stat * sb,
 		if (rc != Z_OK) {
 			free(cce->trailer);
 			cce->trailer = NULL;
+		} else {
+			/* We can supply the trailer data from the cache. */
+			skiplen += cce->ccr->tlen;
 		}
-
-		/* We can supply the trailer data from the cache. */
-		skiplen += cce->ccr->tlen;
 	} else {
 		cce->trailer = NULL;
 	}

--- a/tar/getdate.c
+++ b/tar/getdate.c
@@ -719,7 +719,7 @@ Convert(time_t Month, time_t Day, time_t Year,
 	    ? 29 : 28;
 	/* Checking for 2038 bogusly assumes that time_t is 32 bits.  But
 	   I'm too lazy to try to check for time_t overflow in another way.  */
-	if (Year < EPOCH || Year >= 2038
+	if (Year < EPOCH || (sizeof(time_t) <= 4 && Year >= 2038)
 	    || Month < 1 || Month > 12
 	    /* Lint fluff:  "conversion from long may lose accuracy" */
 	    || Day < 1 || Day > DaysInMonth[(int)--Month])

--- a/tar/getdate.c
+++ b/tar/getdate.c
@@ -53,7 +53,7 @@ enum DSTMODE { DSTon, DSToff, DSTmaybe };
 enum { tAM, tPM };
 /* Token types returned by nexttoken() */
 enum { tAGO = 260, tDAY, tDAYZONE, tAMPM, tMONTH, tMONTH_UNIT, tSEC_UNIT,
-       tUNUMBER, tZONE, tDST };
+       tUNUMBER, tZONE, tDST, tERROR };
 struct token { int token; time_t value; };
 
 /*
@@ -867,9 +867,24 @@ nexttoken(char **in, time_t *value)
 		 * don't deal with signed numbers here.
 		 */
 		if (isdigit((unsigned char)(c = **in))) {
-			for (*value = 0; isdigit((unsigned char)(c = *(*in)++)); )
-				*value = 10 * *value + c - '0';
+			unsigned long long val = 0;
+			int overflow = 0;
+			unsigned long long tmax = ~0ULL;
+			if (sizeof(time_t) == 4)
+				tmax = ((time_t)-1 > 0) ? 0xFFFFFFFFULL : 0x7FFFFFFFULL;
+			else if (sizeof(time_t) == 8)
+				tmax = ((time_t)-1 > 0) ? 0xFFFFFFFFFFFFFFFFULL : 0x7FFFFFFFFFFFFFFFULL;
+
+			for (; isdigit((unsigned char)(c = *(*in)++)); ) {
+				if (val > (~0ULL - (c - '0')) / 10)
+					overflow = 1;
+				else
+					val = 10 * val + c - '0';
+			}
 			(*in)--;
+			if (overflow || val > tmax)
+				return (tERROR);
+			*value = (time_t)val;
 			return (tUNUMBER);
 		}
 

--- a/tar/multitape/multitape_stats.c
+++ b/tar/multitape/multitape_stats.c
@@ -236,6 +236,12 @@ statstape_printlist_item(TAPE_S * d, const uint8_t tapehash[32], int verbose,
 	char datebuf[DATEBUFLEN];
 	int arg;
 
+	/*
+	 * tmd is not filled in until multitape_metadata_get_byhash() below,
+	 * but the error path frees it; make that safe.
+	 */
+	memset(&tmd, 0, sizeof(tmd));
+
 	/* Print archive hash. */
 	if (print_hash) {
 		hexify(tapehash, hexstr, 32);

--- a/tar/subst.c
+++ b/tar/subst.c
@@ -225,6 +225,9 @@ apply_substitution(struct bsdtar *bsdtar, const char *name, char **result, int s
 
 			++i;
 			c = (unsigned char)rule->result[i];
+			if (c == '\0') {
+				break;
+			}
 			switch (c) {
 			case '~':
 			case '\\':


### PR DESCRIPTION
This PR fixes three bugs:

- tar/getdate.c: handle dates in 2038 and beyond if time_t is big enough (Fixes #766)
- tar/ccache/ccache_entry.c: only add trailer length if it decompressed properly (Fixes #767)
- tar/subst.c: handle trailing backslash in replacement (Fixes #761)