### PR TITLE
Fix bugs #753-#765

### DIFF
--- a/keygen/keygen.c
+++ b/keygen/keygen.c
@@ -129,7 +129,8 @@ main(int argc, char **argv)
 	(void)argv; /* argv is not used beyond this point. */
 
 	/* We must have a user name, machine name, and key file specified. */
-	if ((C.user == NULL) || (C.name == NULL) || (keyfilename == NULL))
+	if ((C.user == NULL) || (C.name == NULL) || (keyfilename == NULL) ||
+	    (keyfilename[0] == '\0'))
 		usage();
 
 	/*

--- a/keyregen/keyregen.c
+++ b/keyregen/keyregen.c
@@ -143,7 +143,8 @@ main(int argc, char **argv)
 	 * file specified.
 	 */
 	if ((C.user == NULL) || (C.name == NULL) ||
-	    (keyfilename == NULL) || (oldkeyfilename == NULL))
+	    (keyfilename == NULL) || (keyfilename[0] == '\0') ||
+	    (oldkeyfilename == NULL) || (oldkeyfilename[0] == '\0'))
 		usage();
 
 	/*

--- a/lib/crypto/crypto_keys_subr.c
+++ b/lib/crypto/crypto_keys_subr.c
@@ -55,7 +55,7 @@ import_BN(BIGNUM ** bn, const uint8_t ** buf, size_t * buflen)
 	*buflen -= sizeof(uint32_t);
 
 	/* Sanity check. */
-	if (len > INT_MAX) {
+	if ((len == 0) || (len > INT_MAX)) {
 		warn0("Unexpected key length");
 		goto err0;
 	}
@@ -143,7 +143,7 @@ export_BN(const BIGNUM * bn, uint8_t ** buf, size_t * buflen,
 	BN_bn2bin(bn, *buf);
 
 	/* Convert to little-endian format. */
-	for (i = 0; i < bnlen - 1 - i; i++) {
+	for (i = 0; i < bnlen / 2; i++) {
 		(*buf)[i] ^= (*buf)[bnlen - 1 - i];
 		(*buf)[bnlen - 1 - i] ^= (*buf)[i];
 		(*buf)[i] ^= (*buf)[bnlen - 1 - i];

--- a/recrypt/recrypt.c
+++ b/recrypt/recrypt.c
@@ -683,6 +683,12 @@ main(int argc, char **argv)
 		exit(1);
 	}
 
+	/* Stage an empty directory before we commit the deletion. */
+	if (chunks_transaction_empty(ocachedir)) {
+		warnp("Cannot stage empty chunk directory");
+		exit(1);
+	}
+
 	/* Commit the delete transaction and delete the old chunk dir. */
 	printf("Committing block deletes...");
 	if (multitape_commit(ocachedir, omachinenum, oseqnum, 1,

--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -1152,6 +1152,23 @@ main(int argc, char **argv)
 	}
 
 	/*
+	 * Make the CSV filename absolute if necessary, since the tar code
+	 * can change directories.
+	 */
+	if (bsdtar->option_csv_filename != NULL &&
+	    bsdtar->option_csv_filename[0] != '/') {
+		char cwd[PATH_MAX];
+		if (getcwd(cwd, PATH_MAX) == NULL)
+			bsdtar_errc(bsdtar, 1, errno, "getcwd");
+		char *newpath = malloc(strlen(cwd) + strlen(bsdtar->option_csv_filename) + 2);
+		if (newpath == NULL)
+			bsdtar_errc(bsdtar, 1, errno, "Out of memory");
+		sprintf(newpath, "%s/%s", cwd, bsdtar->option_csv_filename);
+		free(bsdtar->option_csv_filename);
+		bsdtar->option_csv_filename = newpath;
+	}
+
+	/*
 	 * Canonicalize the path to the cache directories.  This is
 	 * necessary since the tar code can change directories.
 	 */

--- a/tar/ccache/ccache_entry.c
+++ b/tar/ccache/ccache_entry.c
@@ -326,10 +326,10 @@ ccache_entry_lookup(CCACHE * cache, const char * path, const struct stat * sb,
 		if (rc != Z_OK) {
 			free(cce->trailer);
 			cce->trailer = NULL;
+		} else {
+			/* We can supply the trailer data from the cache. */
+			skiplen += cce->ccr->tlen;
 		}
-
-		/* We can supply the trailer data from the cache. */
-		skiplen += cce->ccr->tlen;
 	} else {
 		cce->trailer = NULL;
 	}

--- a/tar/chunks/chunks.h
+++ b/tar/chunks/chunks.h
@@ -65,12 +65,12 @@ ssize_t chunks_write_chunk(CHUNKS_W *, const uint8_t *, const uint8_t *,
 int chunks_write_ispresent(CHUNKS_W *, const uint8_t *);
 
 /**
- * chunks_write_chunkref(C, hash):
- * If a chunk with hash ${hash} exists, mark it as being part of the write
- * transaction associated with the cookie ${C} and return 0.  If it
- * does not exist, return 1.
+ * chunks_write_chunkref(C, hash, len, zlen):
+ * If a chunk with hash ${hash}, length ${len}, and compressed length ${zlen}
+ * exists, mark it as being part of the write transaction associated with
+ * the cookie ${C} and return 0.  If it does not exist, return 1.
  */
-int chunks_write_chunkref(CHUNKS_W *, const uint8_t *);
+int chunks_write_chunkref(CHUNKS_W *, const uint8_t *, size_t, size_t);
 
 /**
  * chunks_write_extrastats(C, len):
@@ -222,6 +222,12 @@ int chunks_stats_printarchive(FILE *, CHUNKS_S *, const char *, int, int);
  * No more calls will be made to chunks_stats* functions.
  */
 void chunks_stats_free(CHUNKS_S *);
+
+/**
+ * chunks_transaction_empty(cachepath):
+ * Stage an empty chunk directory transaction.
+ */
+int chunks_transaction_empty(const char *);
 
 /**
  * chunks_transaction_checkpoint(cachepath):

--- a/tar/chunks/chunks_directory.c
+++ b/tar/chunks/chunks_directory.c
@@ -249,7 +249,7 @@ chunks_directory_read(const char * cachepath, void ** dir,
 		/* ... creating struct chunkdata records... */
 		memcpy(p->hash, che.hash, 32);
 		p->len = le32dec(che.len);
-		p->zlen_flags = le32dec(che.zlen);
+		p->zlen_flags = le32dec(che.zlen) & CHDATA_ZLEN;
 		p->nrefs = le32dec(che.nrefs);
 		p->ncopies = le32dec(che.ncopies);
 

--- a/tar/chunks/chunks_write.c
+++ b/tar/chunks/chunks_write.c
@@ -267,13 +267,13 @@ chunks_write_ispresent(CHUNKS_W * C, const uint8_t * hash)
 }
 
 /**
- * chunks_write_chunkref(C, hash):
- * If a chunk with hash ${hash} exists, mark it as being part of the write
- * transaction associated with the cookie ${C} and return 0.  If it
- * does not exist, return 1.
+ * chunks_write_chunkref(C, hash, len, zlen):
+ * If a chunk with hash ${hash}, length ${len}, and compressed length ${zlen}
+ * exists, mark it as being part of the write transaction associated with
+ * the cookie ${C} and return 0.  If it does not exist, return 1.
  */
 int
-chunks_write_chunkref(CHUNKS_W * C, const uint8_t * hash)
+chunks_write_chunkref(CHUNKS_W * C, const uint8_t * hash, size_t len, size_t zlen)
 {
 	struct chunkdata * ch;
 
@@ -282,6 +282,8 @@ chunks_write_chunkref(CHUNKS_W * C, const uint8_t * hash)
 	 * transaction and return 0.
 	 */
 	if ((ch = rwhashtab_read(C->HT, hash)) != NULL) {
+		if (ch->len != len || (ch->zlen_flags & CHDATA_ZLEN) != zlen)
+			return (1);
 		chunks_stats_add(&C->stats_total, ch->len,
 		    ch->zlen_flags & CHDATA_ZLEN, 1);
 		chunks_stats_add(&C->stats_tape, ch->len,

--- a/tar/getdate.c
+++ b/tar/getdate.c
@@ -719,7 +719,7 @@ Convert(time_t Month, time_t Day, time_t Year,
 	    ? 29 : 28;
 	/* Checking for 2038 bogusly assumes that time_t is 32 bits.  But
 	   I'm too lazy to try to check for time_t overflow in another way.  */
-	if (Year < EPOCH || Year >= 2038
+	if (Year < EPOCH || (sizeof(time_t) <= 4 && Year >= 2038)
 	    || Month < 1 || Month > 12
 	    /* Lint fluff:  "conversion from long may lose accuracy" */
 	    || Day < 1 || Day > DaysInMonth[(int)--Month])

--- a/tar/getdate.c
+++ b/tar/getdate.c
@@ -53,7 +53,7 @@ enum DSTMODE { DSTon, DSToff, DSTmaybe };
 enum { tAM, tPM };
 /* Token types returned by nexttoken() */
 enum { tAGO = 260, tDAY, tDAYZONE, tAMPM, tMONTH, tMONTH_UNIT, tSEC_UNIT,
-       tUNUMBER, tZONE, tDST };
+       tUNUMBER, tZONE, tDST, tERROR };
 struct token { int token; time_t value; };
 
 /*
@@ -867,9 +867,24 @@ nexttoken(char **in, time_t *value)
 		 * don't deal with signed numbers here.
 		 */
 		if (isdigit((unsigned char)(c = **in))) {
-			for (*value = 0; isdigit((unsigned char)(c = *(*in)++)); )
-				*value = 10 * *value + c - '0';
+			unsigned long long val = 0;
+			int overflow = 0;
+			unsigned long long tmax = ~0ULL;
+			if (sizeof(time_t) == 4)
+				tmax = ((time_t)-1 > 0) ? 0xFFFFFFFFULL : 0x7FFFFFFFULL;
+			else if (sizeof(time_t) == 8)
+				tmax = ((time_t)-1 > 0) ? 0xFFFFFFFFFFFFFFFFULL : 0x7FFFFFFFFFFFFFFFULL;
+
+			for (; isdigit((unsigned char)(c = *(*in)++)); ) {
+				if (val > (~0ULL - (c - '0')) / 10)
+					overflow = 1;
+				else
+					val = 10 * val + c - '0';
+			}
 			(*in)--;
+			if (overflow || val > tmax)
+				return (tERROR);
+			*value = (time_t)val;
 			return (tUNUMBER);
 		}
 

--- a/tar/getdate.c
+++ b/tar/getdate.c
@@ -368,8 +368,8 @@ relunitphrase(struct gdstate *gds)
 	    && gds->tokenp[1].token == tSEC_UNIT) {
 		/* "1 day" */
 		gds->HaveRel++;
-		gds->RelSeconds += gds->tokenp[1].value * gds->tokenp[2].value;
-		gds->tokenp += 3;
+		gds->RelSeconds += gds->tokenp[0].value * gds->tokenp[1].value;
+		gds->tokenp += 2;
 		return 1;
 	}
 	if (gds->tokenp[0].token == '-'
@@ -754,26 +754,30 @@ DSTcorrect(time_t Start, time_t Future)
 }
 
 
-static time_t
-RelativeDate(time_t Start, time_t zone, int dstmode,
+static int
+RelativeDate(time_t *Start, time_t zone, int dstmode,
     time_t DayOrdinal, time_t DayNumber)
 {
 	struct tm	*tm;
 	time_t	t, now;
 
-	t = Start - zone;
+	t = *Start - zone;
 	tm = gmtime(&t);
-	now = Start;
+	if (tm == NULL)
+		return -1;
+	now = *Start;
 	now += DAY * ((DayNumber - tm->tm_wday + 7) % 7);
 	now += 7 * DAY * (DayOrdinal <= 0 ? DayOrdinal : DayOrdinal - 1);
 	if (dstmode == DSTmaybe)
-		return DSTcorrect(Start, now);
-	return now - Start;
+		*Start += DSTcorrect(*Start, now);
+	else
+		*Start += now - *Start;
+	return 0;
 }
 
 
-static time_t
-RelativeMonth(time_t Start, time_t Timezone, time_t RelMonth)
+static int
+RelativeMonth(time_t *Start, time_t Timezone, time_t RelMonth)
 {
 	struct tm	*tm;
 	time_t	Month;
@@ -781,14 +785,17 @@ RelativeMonth(time_t Start, time_t Timezone, time_t RelMonth)
 
 	if (RelMonth == 0)
 		return 0;
-	tm = localtime(&Start);
+	tm = localtime(Start);
+	if (tm == NULL)
+		return -1;
 	Month = 12 * (tm->tm_year + 1900) + tm->tm_mon + RelMonth;
 	Year = Month / 12;
 	Month = Month % 12 + 1;
-	return DSTcorrect(Start,
+	*Start += DSTcorrect(*Start,
 	    Convert(Month, (time_t)tm->tm_mday, Year,
 		(time_t)tm->tm_hour, (time_t)tm->tm_min, (time_t)tm->tm_sec,
 		Timezone, DSTmaybe));
+	return 0;
 }
 
 /*
@@ -1027,14 +1034,15 @@ get_date(time_t now, char *p)
 
 	/* Add the relative offset. */
 	Start += gds->RelSeconds;
-	Start += RelativeMonth(Start, gds->Timezone, gds->RelMonth);
+	if (RelativeMonth(&Start, gds->Timezone, gds->RelMonth) != 0)
+		return -1;
 
 	/* Adjust for day-of-week offsets. */
 	if (gds->HaveWeekDay
 	    && !(gds->HaveYear || gds->HaveMonth || gds->HaveDay)) {
-		tod = RelativeDate(Start, gds->Timezone,
-		    gds->DSTmode, gds->DayOrdinal, gds->DayNumber);
-		Start += tod;
+		if (RelativeDate(&Start, gds->Timezone,
+		    gds->DSTmode, gds->DayOrdinal, gds->DayNumber) != 0)
+			return -1;
 	}
 
 	/* -1 is an error indicator, so return 0 instead of -1 if

--- a/tar/multitape/multitape_chunkiter.c
+++ b/tar/multitape/multitape_chunkiter.c
@@ -93,8 +93,10 @@ multitape_chunkiter_tmd(STORAGE_R * S, CHUNKS_S * C,
 		}
 
 		/* We want to cache this chunk after reading it. */
-		if (chunks_read_cache(CR, ch->hash))
+		if (chunks_read_cache(CR, ch->hash)) {
+			rc = -1;
 			goto err3;
+		}
 
 		/* Read the chunk into buffer. */
 		if ((rc = chunks_read_chunk(CR, ch->hash, chunklen, chunkzlen,

--- a/tar/multitape/multitape_stats.c
+++ b/tar/multitape/multitape_stats.c
@@ -236,6 +236,12 @@ statstape_printlist_item(TAPE_S * d, const uint8_t tapehash[32], int verbose,
 	char datebuf[DATEBUFLEN];
 	int arg;
 
+	/*
+	 * tmd is not filled in until multitape_metadata_get_byhash() below,
+	 * but the error path frees it; make that safe.
+	 */
+	memset(&tmd, 0, sizeof(tmd));
+
 	/* Print archive hash. */
 	if (print_hash) {
 		hexify(tapehash, hexstr, 32);

--- a/tar/multitape/multitape_write.c
+++ b/tar/multitape/multitape_write.c
@@ -678,7 +678,8 @@ writetape_writechunk(TAPE_W * d, struct chunkheader * ch)
 		goto notpresent;
 
 	/* Attempt to reference the chunk. */
-	switch (chunks_write_chunkref(d->C, ch->hash)) {
+	switch (chunks_write_chunkref(d->C, ch->hash,
+	    le32dec(ch->len), le32dec(ch->zlen))) {
 	case -1:
 		goto err0;
 	case 1:

--- a/tar/subst.c
+++ b/tar/subst.c
@@ -225,6 +225,9 @@ apply_substitution(struct bsdtar *bsdtar, const char *name, char **result, int s
 
 			++i;
 			c = (unsigned char)rule->result[i];
+			if (c == '\0') {
+				break;
+			}
 			switch (c) {
 			case '~':
 			case '\\':


### PR DESCRIPTION
This PR fixes 9 more bugs from the bug bounty program:

- tar/getdate.c: fix relunitphrase count and sign inversion (Fixes #765)
- tar/chunks/: verify zlen against cache directory (Fixes #764)
- tar/multitape/multitape_chunkiter.c: check chunks_read_cache error (Fixes #760)
- tar/getdate.c: check localtime/gmtime for NULL (Fixes #759)
- recrypt/recrypt.c: stage empty directory before old-machine commit (Fixes #757)
- keygen/keygen.c, keyregen/keyregen.c: reject empty keyfile path (Fixes #756)
- tar/bsdtar.c: make csv_filename absolute before -C (Fixes #755)
- tar/chunks/chunks_directory.c: mask CHDATA_ZLEN flags (Fixes #754)
- lib/crypto/crypto_keys_subr.c: handle zero-length BN safely (Fixes #753)