### PR TITLE
fix: treat empty XDG_CONFIG_HOME as unset per XDG spec

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -925,7 +925,7 @@ main(int argc, char **argv)
 		}
 
 		/* Check if ${XDG_CONFIG_HOME} is set. */
-		if ((xdg_configdir = getenv("XDG_CONFIG_HOME")) != NULL) {
+		if ((xdg_configdir = getenv("XDG_CONFIG_HOME")) != NULL && xdg_configdir[0] != '\0') {
 			/*
 			 * If it exists, use
 			 * ${XDG_CONFIG_HOME}/tarsnap/tarsnap.conf


### PR DESCRIPTION
## Summary

Fixes #786

When `XDG_CONFIG_HOME` is set but **empty**, tarsnap constructed the path `/tarsnap/tarsnap.conf` (filesystem root) instead of falling back to `$HOME/.config/tarsnap/tarsnap.conf`. This silently skipped the per-user configuration file.

## Root Cause

In `tar/bsdtar.c`, the code only checked if `getenv("XDG_CONFIG_HOME")` was non-NULL:

```c
if ((xdg_configdir = getenv("XDG_CONFIG_HOME")) != NULL) {
    asprintf(&bsdtar->conffile, "%s/tarsnap/tarsnap.conf", xdg_configdir);
}
```

An empty string is non-NULL, so it produced `/tarsnap/tarsnap.conf`.

## Fix

Added an additional check for `xdg_configdir[0] != '\0'` so an empty value falls through to the `else if` branch, which uses the standard `\/root/.config/tarsnap/tarsnap.conf` fallback — consistent with the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/), which states:

> If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used.

## Repro

```sh
# Before fix (broken):
$ env XDG_CONFIG_HOME= tarsnap --dump-config -c -f x somefile
Reading from config file: /tarsnap/tarsnap.conf   # <-- wrong, filesystem root

# After fix (correct):
$ env XDG_CONFIG_HOME= tarsnap --dump-config -c -f x somefile
Reading from config file: /Users/user/.config/tarsnap/tarsnap.conf  # <-- correct fallback
```

## Changes

- `tar/bsdtar.c`: One-line change — added `&& xdg_configdir[0] != '\0'` to the condition.