### PR TITLE
fix(bsdtar): validate --disk-pause values instead of silently zeroing (fixes #787)

### DIFF
--- a/tar/bsdtar.c
+++ b/tar/bsdtar.c
@@ -1707,10 +1707,13 @@ dooption(struct bsdtar *bsdtar, const char * conf_opt,
 		if (conf_arg == NULL)
 			goto needarg;
 
-		bsdtar->disk_pause = strtol(conf_arg, NULL, 0);
-		if (bsdtar->disk_pause > 1000)
+		errno = 0;
+		eptr = NULL;
+		bsdtar->disk_pause = (int)strtol(conf_arg, &eptr, 10);
+		if ((errno == ERANGE) || (eptr == conf_arg) ||
+		    (*eptr != '\0') || (bsdtar->disk_pause > 1000))
 			bsdtar_errc(bsdtar, 1, 0,
-			    "disk-pause value must be <= 1000");
+			    "Invalid disk-pause value: %s", conf_arg);
 		if (bsdtar->disk_pause < 0)
 			bsdtar_errc(bsdtar, 1, 0,
 			    "disk-pause value must be >= 0");


### PR DESCRIPTION
## Summary

`--disk-pause` called `strtol(conf_arg, NULL, 0)` with **no `errno`/`endptr` check**. A non-numeric value — `abc`, or `1GB` from a config file — silently became `0`, which passed both range checks and **disabled the disk-full pause protection** with exit status 0.

The same function's `maxbw-rate-down`/`maxbw-rate-up` branches validate strictly (`strtod` + `*eptr != '\0'`), so this was an inconsistency/oversight rather than a design choice.

## Fix

Validates identically to the neighbouring bandwidth branches:

- `errno == ERANGE` → reject (also fixes the overflow case: `disk_pause` is an `int`, so a `long` overflow previously truncated and tripped the misleading "must be >= 0" error)
- empty numeric prefix (`eptr == conf_arg`) → reject
- trailing garbage (`*eptr != '\0'`) → reject
- range checks unchanged: `(0, 1000]` accepted, negative keeps its distinct message

## Verification (built & run on macOS/arm64, current master)

| Input | Before | After |
|---|---|---|
| `--disk-pause abc` | silently proceeds, rc=0 | `tarsnap: Invalid disk-pause value: abc`, rc=1 |
| `--disk-pause 1GB` | silently proceeds | rejected |
| `--disk-pause 99999999999999999999` | "must be >= 0" (misleading) | `Invalid disk-pause value: ...` |
| `--disk-pause 250` / `0` / `1000` | ok | ok (unchanged) |
| `--disk-pause 1001` | error | error (unchanged) |
| `--disk-pause -5` | "must be >= 0" | unchanged |

Full build via `autoreconf -i && ./configure && make` passes.

Closes #787