### PR TITLE
fix(keygen): reject empty --keyfile path before prompting for password (fixes #756)

### DIFF
--- a/keygen/keygen_actual.c
+++ b/keygen/keygen_actual.c
@@ -84,6 +84,12 @@ keygen_actual(struct register_internal * C, const char * keyfilename,
 		goto err0;
 	}
 
+	/* Sanity-check the key file name before asking for a password. */
+	if ((keyfilename == NULL) || (keyfilename[0] == '\0')) {
+		fprintf(stderr, "Key file name must be non-empty\n");
+		goto err0;
+	}
+
 	/* Get a password. */
 	if (readpass(&C->passwd, "Enter tarsnap account password", NULL, 0)) {
 		warnp("Error reading password");


### PR DESCRIPTION
## Summary

`--keyfile=` yields a non-NULL empty string, which passed the `keyfilename == NULL` check. `tarsnap-keygen` (and `tarsnap-keyregen`, which shares the path) then prompted for the account **password** before failing with the ambiguous `Cannot create : No such file or directory` at `open("")`.

## Fix

Add a sanity check in `keygen_actual()` — alongside the existing user/machine-name checks and *before* the password prompt:

```c
if ((keyfilename == NULL) || (keyfilename[0] == '\0')) {
	fprintf(stderr, "Key file name must be non-empty\\n");
	goto err0;
}
```

## Verification

| Command | Before | After |
|---|---|---|
| `tarsnap-keygen --user u --machine m --keyfile=` | prompts for password, then `Cannot create :`, rc=1 | `Key file name must be non-empty`, rc=1, no prompt |
| `tarsnap-keygen --user u --machine m` (missing) | usage error | unchanged |
| normal keygen flow | ok | unchanged |

Built via `autoreconf -i && ./configure && make`; binary tested directly.

Closes #756