### PR TITLE
fix(netproto): do not retain fd ownership when writeq init fails (fixes #789)

### DIFF
--- a/lib/netproto/netproto.c
+++ b/lib/netproto/netproto.c
@@ -106,8 +106,16 @@ netproto_setfd(struct netproto_connection_internal * C, int fd)
 	C->fd = fd;
 
 	/* Create a network layer write queue. */
-	if ((C->Q = network_writeq_init(fd)) == NULL)
+	if ((C->Q = network_writeq_init(fd)) == NULL) {
+		/*
+		 * The connection must not retain ownership of ${fd}: the
+		 * caller closes it on this error path, and a later
+		 * netproto_close() would double-close the (possibly
+		 * reused) descriptor.
+		 */
+		C->fd = -1;
 		goto err0;
+	}
 
 	/* Success! */
 	return (0);


### PR DESCRIPTION
## Summary

`netproto_setfd()` stored the connected socket in `C->fd` **before** allocating the write queue:

```c
C->fd = fd;
if ((C->Q = network_writeq_init(fd)) == NULL)
	goto err0;   /* returns -1 with C->fd still == fd */
```

On that allocation-failure path, production `callback_connect()` closes the socket itself — but `C->fd` still owns the (now stale) descriptor number. A later `netproto_close()` executes `close(C->fd)`, which can target an **unrelated file or socket** if the descriptor was reused by the reconnect attempt.

## Fix

Reset `C->fd = -1` on the failure path so ownership stays with the caller, matching the sentinel used by `netproto_alloc()` and checked everywhere via `C->fd != -1`.

```c
if ((C->Q = network_writeq_init(fd)) == NULL) {
	C->fd = -1;
	goto err0;
}
```

## Verification

Full build (`autoreconf -i && ./configure && make`) passes. The change only affects the already-failing allocation path; success paths are byte-for-byte identical.

Closes #789