### PR TITLE
fix(getdate): "<count> <unit> ago" selected a future cutoff (fixes #765)

### DIFF
--- a/tar/getdate.c
+++ b/tar/getdate.c
@@ -368,8 +368,9 @@ relunitphrase(struct gdstate *gds)
 	    && gds->tokenp[1].token == tSEC_UNIT) {
 		/* "1 day" */
 		gds->HaveRel++;
-		gds->RelSeconds += gds->tokenp[1].value * gds->tokenp[2].value;
-		gds->tokenp += 3;
+		gds->RelSeconds += gds->tokenp[0].value *
+		    gds->tokenp[1].value;
+		gds->tokenp += 2;
 		return 1;
 	}
 	if (gds->tokenp[0].token == '-'


### PR DESCRIPTION
## Summary

The `tUNUMBER tSEC_UNIT` branch of `relunitphrase()` — the one matching `"1 day"` — had two compounding bugs:

```c
gds->RelSeconds += gds->tokenp[1].value * gds->tokenp[2].value;  /* unit × NEXT token */
gds->tokenp += 3;                                                /* advanced past 'ago' */
```

1. It multiplied the unit's second-value by the value of the token **after** the two-token match (`ago`, lexicon value 1), so the count was ignored: `7 days ago` behaved identically to `1 day ago`.
2. It advanced the token pointer by 3 after consuming 2 tokens, **skipping `ago`** — so the negation at `phrase()` never fired.

Net effect for `--newer/--newer-ctime/--newer-mtime "N <unit> ago"`: the cutoff landed in the **future**, silently producing an empty archive with exit status 0. The equivalent spellings (`now - 1 day`, `-1 day`, `yesterday`) took different code paths and worked.

## Fix

Use `tokenp[0] * tokenp[1]` and advance by 2. `ago` then remains visible and negates the interval as designed.

## Verification (delta from `now`, patched build)

| Input | Before | After |
|---|---|---|
| `1 day ago` | **+86400** | −86400 |
| `7 days ago` | **+86400** (count ignored) | −604800 |
| `1 hour ago` | +3600 | −3600 |
| `2 weeks ago` | wrong | −1209600 |
| `−1 day` / `yesterday` / `now - 1 day` | −86400 (control) | unchanged |
| "+1 hour", "next month" | ok | unchanged |

The #785 regression harness still passes with this change applied alongside it (both touch `getdate.c`; independent functions).

Closes #765