### PR TITLE
fix(subst): stop escape scan at lone trailing backslash in --subst (fixes #761)

### DIFF
--- a/tar/subst.c
+++ b/tar/subst.c
@@ -225,6 +225,15 @@ apply_substitution(struct bsdtar *bsdtar, const char *name, char **result, int s
 
 			++i;
 			c = (unsigned char)rule->result[i];
+			if (c == '\0') {
+				/*
+				 * Lone trailing backslash: keep it
+				 * literal and stop, instead of letting
+				 * the loop condition read past the end
+				 * of the allocation.
+				 */
+				break;
+			}
 			switch (c) {
 			case '~':
 			case '\\':


### PR DESCRIPTION
## Summary

In `apply_substitution()`, a `--subst` replacement ending with a single backslash (`-s '/f/b\/'`) made the escape-scanning loop consume the NUL terminator; the loop's `++i` then stepped past the allocation and the loop condition scanned heap memory until a stray zero byte — appending garbage bytes to archived filenames (silent corruption) or crashing (ASan heap-buffer-overflow READ at subst.c:214).

## Fix

After the escape `++i`, if the next character is `'\0'`, treat the lone trailing backslash as **literal** and break out of the scan. The final `realloc_strcat(bsdtar, result, rule->result + j)` then appends everything from the last flush point — including the backslash — unchanged.

## Verification

```
$ tarsnap --no-default-config --dry-run -cv -f a -s '/f/b\/' f.txt
a b\.txt          <- single literal backslash, no garbage, rc=0

$ tarsnap ... -s '/f/zz/' f.txt
a zz.txt          <- normal substitution unchanged
```

Full build passes. The new branch only fires where the old code read past the allocation; all well-formed escape sequences behave identically.

Closes #761