### PR TITLE
fix(write): set exit status when an input file cannot be opened (fixes #772)

### DIFF
--- a/tar/write.c
+++ b/tar/write.c
@@ -1091,6 +1091,7 @@ write_entry_backend(struct bsdtar *bsdtar, struct archive *a,
 				    "%s: could not open file", pathname);
 			else
 				fprintf(stderr, ": %s", strerror(errno));
+			bsdtar->return_value = 1;
 			return;
 		}
 	}


### PR DESCRIPTION
## Summary

`write_entry_backend()` abandoned an entry whose file could not be opened (`fileutil_open_noatime()` → −1) but returned **without touching `bsdtar->return_value`**. `bsdtar_warnc()` only prints, so a backup that silently omitted unreadable files still exited **0** — contradicting the documented exit-status contract in `tarsnap.1`.

## Fix

One line on the failure path, consistent with the other input-error paths in `write.c`:

```c
bsdtar->return_value = 1;
return;
```

## Verification

Full build passes. Behavior change is limited to the already-warning failure path: the archive stream itself is unaffected (the entry was already abandoned); only the process exit status changes from 0 to 1, matching what the man page promises.

Closes #772