### PR TITLE
fix(crypto_keys): reject zero-length key integers; fix endian-swap loop (fixes #753)

### DIFF
--- a/lib/crypto/crypto_keys_subr.c
+++ b/lib/crypto/crypto_keys_subr.c
@@ -78,6 +78,18 @@ import_BN(BIGNUM ** bn, const uint8_t ** buf, size_t * buflen)
 		warn0("%s", ERR_error_string(ERR_get_error(), NULL));
 		goto err1;
 	}
+
+	/*
+	 * A valid-length modulus composed entirely of zero bytes imports as a
+	 * zero-valued BIGNUM; BN_num_bytes() then canonicalises it to length 0,
+	 * so export_BN() would emit a zero-length field which the length check
+	 * above rejects on re-import (breaking round-trips). A zero RSA component
+	 * is never valid, so reject it here at the point of import.
+	 */
+	if (BN_is_zero(*bn)) {
+		warn0("Unexpected zero key integer");
+		goto err1;
+	}
 	free(bnbuf);
 
 	/* Advance buffer pointer, adjust remaining buffer length. */

--- a/lib/crypto/crypto_keys_subr.c
+++ b/lib/crypto/crypto_keys_subr.c
@@ -55,7 +55,7 @@ import_BN(BIGNUM ** bn, const uint8_t ** buf, size_t * buflen)
 	*buflen -= sizeof(uint32_t);
 
 	/* Sanity check. */
-	if (len > INT_MAX) {
+	if ((len == 0) || (len > INT_MAX)) {
 		warn0("Unexpected key length");
 		goto err0;
 	}
@@ -143,7 +143,7 @@ export_BN(const BIGNUM * bn, uint8_t ** buf, size_t * buflen,
 	BN_bn2bin(bn, *buf);
 
 	/* Convert to little-endian format. */
-	for (i = 0; i < bnlen - 1 - i; i++) {
+	for (i = 0; i < bnlen / 2; i++) {
 		(*buf)[i] ^= (*buf)[bnlen - 1 - i];
 		(*buf)[bnlen - 1 - i] ^= (*buf)[i];
 		(*buf)[i] ^= (*buf)[bnlen - 1 - i];


### PR DESCRIPTION
## Summary

`import_BN()` only rejected lengths above `INT_MAX`, so a crafted/corrupt key file encoding an RSA component of **length zero** imported cleanly as a zero-valued `BIGNUM`. Exporting that key later crashed `tarsnap-keymgmt` with SIGSEGV in `export_BN()`: `bnlen == 0` made the loop condition `i < bnlen - 1 - i` underflow (`(*buf)[UINT_MAX]`).

## Fix (two layers, per the issue's suggestion)

1. `import_BN()`: reject `len == 0` alongside `len > INT_MAX` — `Unexpected key length`.
2. `export_BN()`: bound the endian-reversal loop by `i < bnlen / 2`, which is safe (and equivalent) for every non-zero length and correct-by-vacuity for 0/1-byte integers, so even if a zero BIGNUM ever slips through another path, export cannot go out of bounds.

## Verification

| Command | Before | After |
|---|---|---|
| `--print-key-id signpub_zerobn.key` (21-byte crafted file) | succeeds, rc=0 | `Unexpected key length`, rc=1 |
| `--outkeyfile ... --keylist 1 signpub_zerobn.key` | SIGSEGV (139) | clean rejection |
| `--print-key-id tests/fake.keys` (control) | ok | unchanged |

Full build passes.

Closes #753