### PR TITLE
fix(multitape): fail writetape_write() if the header append fails (fixes #773)

### DIFF
--- a/tar/multitape/multitape_write.c
+++ b/tar/multitape/multitape_write.c
@@ -622,7 +622,8 @@ writetape_write(TAPE_W * d, const void * buffer, size_t nbytes)
 		/* FALLTHROUGH */
 	case 0:
 		/* We're in header mode.  Append the data to d->hbuf. */
-		bytebuf_append(d->hbuf, buffer, nbytes);
+		if (bytebuf_append(d->hbuf, buffer, nbytes))
+			goto err0;
 	}
 
 	/* Success! */


### PR DESCRIPTION
## Summary

In header mode, `writetape_write()` ignored `bytebuf_append()`'s return value — the only unchecked return in the file — and unconditionally reported `nbytes` written to libarchive. On allocation failure the header bytes were silently dropped; `endentry()` then exported a short-but-internally-consistent header, so the archive committed, verified, and exited 0 while being corrupt at restore time.

## Fix

Check the return value and take the existing error path:

```c
if (bytebuf_append(d->hbuf, buffer, nbytes))
	goto err0;
```

The caller already handles a −1 from `writetape_write()` (`write_entry_backend()` treats it as an entry error), so no other changes are needed.

## Verification

Full build passes. Behavior is unchanged except on the previously-silent allocation-failure path, which now aborts the archive instead of committing corruption.

Closes #773