### PR TITLE
fix(getdate): accept dates in 2038 and beyond when time_t is 64 bits (fixes #766)

### DIFF
--- a/tar/getdate.c
+++ b/tar/getdate.c
@@ -719,7 +719,8 @@ Convert(time_t Month, time_t Day, time_t Year,
 	    ? 29 : 28;
 	/* Checking for 2038 bogusly assumes that time_t is 32 bits.  But
 	   I'm too lazy to try to check for time_t overflow in another way.  */
-	if (Year < EPOCH || Year >= 2038
+	if (Year < EPOCH ||
+	    (sizeof(time_t) <= 4 && Year >= 2038)
 	    || Month < 1 || Month > 12
 	    /* Lint fluff:  "conversion from long may lose accuracy" */
 	    || Day < 1 || Day > DaysInMonth[(int)--Month])


### PR DESCRIPTION
## Summary

`Convert()` unconditionally rejected `Year >= 2038` — a guard written when 32-bit `time_t` was the norm. On 64-bit platforms (everything tarsnap normally builds on), this made `--newer`/`--newer-ctime`/`--newer-mtime` refuse **every** date from 2038-01-01 onward with `Could not parse date`.

## Fix

Gate the year check on the actual width of `time_t`, using the exact one-line change applied upstream in libarchive ([2d987e725f30](https://github.com/libarchive/libarchive/commit/2d987e725f30), 2025-09-26):

```c
if (Year < EPOCH ||
    (sizeof(time_t) <= 4 && Year >= 2038)
    || Month < 1 || Month > 12
```

On 32-bit `time_t` hosts behavior is unchanged; on 64-bit hosts dates through year 2100+ now parse.

## Verification (macOS/arm64, sizeof(time_t)==8)

| `--newer` date | Before | After |
|---|---|---|
| 2037-12-31 | rc=0 | rc=0 |
| 2038-01-01 | rejected, rc=1 | rc=0 |
| 2040-01-01 | rejected | rc=0 |
| 2100-01-01 | rejected | rc=0 |

#785 regression harness still passes (same file, independent function).

Closes #766