### PR TITLE
fix(storage): pass the real transaction nonce to TRYCOMMIT after ISCHECKPOINTED (fixes #758)

### DIFF
--- a/lib/netpacket/packets.txt
+++ b/lib/netpacket/packets.txt
@@ -340,8 +340,11 @@ NETPACKET_TRANSACTION_ISCHECKPOINTED_RESPONSE (0x96)
 
 Packet contents:
 	uint8_t status
-	uint8_t tnonce[32]
 	uint8_t hmac[32]
+	uint8_t tnonce[32]
+
+The value hmac is HMAC(key, 0x96 || nonce || status), i.e. it covers
+the status byte only; the tnonce follows at offset 33.
 
 The value status is
 	0	No transaction is in progress, the transaction in progress is

--- a/tar/storage/storage_transaction.c
+++ b/tar/storage/storage_transaction.c
@@ -898,7 +898,13 @@ callback_ischeckpointed_response(void * cookie, NETPACKET_CONNECTION * NPC,
 
 	/* Record status. */
 	C->status = packetbuf[0];
-	memcpy(C->tnonce, &packetbuf[1], 32);
+	/*
+	 * The response layout is status[1] || hmac[32] || tnonce[32]:
+	 * netpacket_hmac_verify(..., 1, ...) checks packetbuf[1..32]
+	 * against HMAC(status), so the transaction nonce begins at
+	 * offset 33.
+	 */
+	memcpy(C->tnonce, &packetbuf[33], 32);
 
 	/* We're done! */
 	C->done = 1;


### PR DESCRIPTION
## Summary

`callback_ischeckpointed_response()` verified the response with `netpacket_hmac_verify(..., pos=1, ...)`. Per the verifier's contract, that checks `packetbuf[1..32]` against `HMAC(type || nonce || status)` — so for any validly signed response, bytes 1–32 **are the HMAC tag**. The callback then did:

```c
memcpy(C->tnonce, &packetbuf[1], 32);   /* copies the HMAC, not the nonce */
```

so `storage_transaction_commitfromcheckpoint()` (`--recover`, `--fsck`, automatic recovery) passed the HMAC to `TRYCOMMIT` as the transaction nonce. The server sees a nonce mismatch and does not commit — yet the client recorded success and `storage_modified`.

## Fix

The shipped verifier pins the wire layout to `status || hmac[32] || tnonce[32]` (65 bytes). Copy the nonce from where it actually lives, and correct `packets.txt`, which documented the opposite order:

```c
memcpy(C->tnonce, &packetbuf[33], 32);
```

## Verification

- Full build passes.
- Layout derived directly from `netpacket_hmac_verify()`'s documented semantics (`lib/netpacket/netpacket_hmac.c:25-31`) rather than assumed; no other response packet carries payload beyond its HMAC, so this is the only affected callback.
- Client-side only; no server-behavior change is required or implied.

Closes #758