### PR TITLE
fix(ccache): do not report fullentry when the cached trailer is corrupt (fixes #767)

### DIFF
--- a/tar/ccache/ccache_entry.c
+++ b/tar/ccache/ccache_entry.c
@@ -329,7 +329,8 @@ ccache_entry_lookup(CCACHE * cache, const char * path, const struct stat * sb,
 		}
 
 		/* We can supply the trailer data from the cache. */
-		skiplen += cce->ccr->tlen;
+		if (cce->trailer != NULL)
+			skiplen += cce->ccr->tlen;
 	} else {
 		cce->trailer = NULL;
 	}


### PR DESCRIPTION
## Summary

In `ccache_entry_lookup()`, the line

```c
/* We can supply the trailer data from the cache. */
skiplen += cce->ccr->tlen;
```

ran **unconditionally after** the decompression-failure cleanup had just freed `cce->trailer`. The stale `tlen` stayed in `skiplen`, so `*fullentry` came back 1 for an entry that was now `tlen` bytes short. `write.c` trusted it, hit the short write, and `exit(1)`ed inside `write_entry_backend()` — **before** `ccache_write()` could rewrite the damaged cache — making every subsequent backup fail identically until the user hand-deleted `${cachedir}/cache`.

## Fix

Only count the trailer toward `skiplen` if it actually decompressed:

```c
if (cce->trailer != NULL)
	skiplen += cce->ccr->tlen;
```

With a corrupt trailer the cache now correctly reports `fullentry=0`; the normal re-chunkification path handles the file, and the corrupt compressed trailer is still discarded via the existing cleanup below, so the cache heals on the next `ccache_write()`.

## Verification

Full build passes. Behavior changes only on the already-warned (`Warning: cached trailer is corrupt`) path: instead of aborting the whole run one line later, tarsnap falls back to reading the file and completes normally.

Closes #767