### PR TITLE
fix(multitape): zero tapemetadata before early error paths (fixes #770)

### DIFF
--- a/tar/multitape/multitape_stats.c
+++ b/tar/multitape/multitape_stats.c
@@ -231,6 +231,13 @@ statstape_printlist_item(TAPE_S * d, const uint8_t tapehash[32], int verbose,
     int print_nulls, int print_hash)
 {
 	struct tapemetadata tmd;
+
+	/*
+	 * Zero the metadata: several early error paths (stdout write
+	 * failures) reach err1 and call multitape_metadata_free() before
+	 * multitape_metadata_get_byhash() has populated the structure.
+	 */
+	memset(&tmd, 0, sizeof(tmd));
 	char hexstr[65];
 	struct tm * ltime;
 	char datebuf[DATEBUFLEN];


### PR DESCRIPTION
## Summary

`statstape_printlist_item()` declared an **uninitialised** `struct tapemetadata tmd`, then had multiple `goto err1` exits — every `print_separator(stdout, ...)` failure, i.e. any stdout write error — which fire *before* `multitape_metadata_get_byhash()` populates the struct. `err1:` calls `multitape_metadata_free(&tmd)`, which unconditionally reads `mdat->argc` and frees `mdat->argv`/`mdat->name`: freeing garbage pointers from stack memory. With a repeated listing (`--list-archives` looping over many archives) a stdout failure crashes the process.

## Fix

Zero-initialise `tmd` immediately after declaration with an explanatory comment. `multitape_metadata_free()` on an all-zero struct then behaves exactly like `free(NULL)` (`argc == 0`, NULL pointers), matching the function's own documented "Behave consistently with free(NULL)" contract.

## Verification

Full build passes; no behavior change on success paths or on errors after metadata is loaded — only the pre-load error paths become safe.

Closes #770