### PR TITLE
fix(multitape): validate cached chunk lengths against the chunk directory (fixes #764)

### DIFF
--- a/tar/chunks/chunks.h
+++ b/tar/chunks/chunks.h
@@ -65,6 +65,14 @@ ssize_t chunks_write_chunk(CHUNKS_W *, const uint8_t *, const uint8_t *,
 int chunks_write_ispresent(CHUNKS_W *, const uint8_t *);
 
 /**
+ * chunks_write_getlens(C, hash, len, zlen):
+ * If a chunk with hash ${hash} exists, store its canonical length and
+ * compressed length into ${len} and ${zlen} and return 0; otherwise,
+ * return 1.
+ */
+int chunks_write_getlens(CHUNKS_W *, const uint8_t *, uint32_t *, uint32_t *);
+
+/**
  * chunks_write_chunkref(C, hash):
  * If a chunk with hash ${hash} exists, mark it as being part of the write
  * transaction associated with the cookie ${C} and return 0.  If it

--- a/tar/chunks/chunks_write.c
+++ b/tar/chunks/chunks_write.c
@@ -267,6 +267,30 @@ chunks_write_ispresent(CHUNKS_W * C, const uint8_t * hash)
 }
 
 /**
+ * chunks_write_getlens(C, hash, len, zlen):
+ * If a chunk with hash ${hash} exists, store its canonical length and
+ * compressed length into ${len} and ${zlen} and return 0; otherwise,
+ * return 1.
+ */
+int
+chunks_write_getlens(CHUNKS_W * C, const uint8_t * hash, uint32_t * len,
+    uint32_t * zlen)
+{
+	struct chunkdata * ch;
+
+	/* If the chunk does not exist, we have no lengths to report. */
+	if ((ch = rwhashtab_read(C->HT, hash)) == NULL)
+		return (1);
+
+	/* Report the canonical lengths. */
+	*len = ch->len;
+	*zlen = ch->zlen_flags & CHDATA_ZLEN;
+
+	/* Success! */
+	return (0);
+}
+
+/**
  * chunks_write_chunkref(C, hash):
  * If a chunk with hash ${hash} exists, mark it as being part of the write
  * transaction associated with the cookie ${C} and return 0.  If it

--- a/tar/multitape/multitape_write.c
+++ b/tar/multitape/multitape_write.c
@@ -644,11 +644,27 @@ err0:
 ssize_t
 writetape_ischunkpresent(TAPE_W * d, struct chunkheader * ch)
 {
+	uint32_t clen;
+	uint32_t czlen;
 
-	if (chunks_write_ispresent(d->C, ch->hash) == 0)
-		return ((ssize_t)le32dec(ch->len));
-	else
+	if (chunks_write_ispresent(d->C, ch->hash) != 0)
 		return (0);
+
+	/*
+	 * The cached header might be corrupt; compare its lengths against
+	 * the canonical values in the chunk directory.  On a mismatch,
+	 * treat the chunk as not present so that it gets re-chunkified,
+	 * rather than writing the corrupt lengths into the archive's
+	 * chunk index.
+	 */
+	if (chunks_write_getlens(d->C, ch->hash, &clen, &czlen))
+		return (0);
+	if ((le32dec(ch->len) != clen) || (le32dec(ch->zlen) != czlen)) {
+		warn0("Cached chunk header is corrupt");
+		return (0);
+	}
+
+	return ((ssize_t)le32dec(ch->len));
 }
 
 /**


### PR DESCRIPTION
## Summary

A fresh chunkification-cache hit only asked `chunks_write_ispresent()` whether each cached hash existed — it never compared the cached header's `len`/`zlen` with the canonical values in the chunk directory. A single-bit corruption of a cached `zlen` therefore flowed, verbatim, into the new archive's chunk index via `writetape_writechunk()`: the backup exited 0 without rereading the file, and restoring that entry later failed because storage rejected the length mismatch.

## Fix (per the issue's suggested direction)

1. **New API** `chunks_write_getlens(C, hash, &len, &zlen)` in the chunks layer: looks up the canonical lengths from the in-memory chunk directory (`zlen` masked out of `zlen_flags`, exactly as the existing stats code does).
2. **Validation at the trust boundary**: `writetape_ischunkpresent()` now compares the cached header's `le32dec(len)`/`le32dec(zlen)` against the canonical values. On mismatch: `warn0("Cached chunk header is corrupt")` and return 0 (chunk not present), so the affected chunk is **re-chunkified from source data** instead of propagating corruption into the index. This matches the project's existing position (b67f5a6) that the cache is an optimization whose damage must never cause data loss.

## Verification

- Full build passes.
- The new code path fires only when cached lengths disagree with the directory; all healthy-cache behavior is byte-for-byte identical (same values returned as before).
- On mismatch the archive remains restorable by construction: the chunk index receives only directory-canonical headers.

Closes #764