### PR TITLE
Fix verbose listing for unrepresentable mtimes

### DIFF
--- a/tar/util.c
+++ b/tar/util.c
@@ -704,6 +704,7 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
 	size_t			 w;
 	const char		*p;
 	const char		*fmt;
+	struct tm		*ltime;
 	time_t			 tim;
 	static time_t		 now;
 
@@ -797,7 +798,10 @@ list_item_verbose(struct bsdtar *bsdtar, FILE *out, struct archive_entry *entry)
 			fmt = bsdtar->day_first ? "%e %b %H:%M" : "%b %e %H:%M";
 #endif
 	}
-	strftime(tmp, sizeof(tmp), fmt, localtime(&tim));
+	ltime = localtime(&tim);
+	if ((ltime == NULL) ||
+	    (strftime(tmp, sizeof(tmp), fmt, ltime) == 0))
+		strcpy(tmp, "-- -- ----");
 	print_separator(out, " ", bsdtar->option_null_output, 2);
 	fprintf(out, "%s", tmp);
 	print_separator(out, " ", bsdtar->option_null_output, 2);


### PR DESCRIPTION
Fixes #805.

## Summary

- check whether `localtime()` can represent an archive entry's mtime before passing the result to `strftime()`
- use the existing libarchive-style `-- -- ----` placeholder if either conversion or formatting fails

## Validation

- built the client on macOS (`tarsnap 1.0.41-head`)
- built unmodified and patched clients in the same Debian/glibc container
- on a tmpfs file with `mtime = 2^60`, the unmodified client exited 139 with `SIGSEGV`
- the patched client exited 0 and printed:

```text
a -rw-r--r--  1 root   root        0 -- -- ---- dev/shm/tarsnap-extreme-mtime
```

## LLM disclosure and availability

This change and pull-request description were prepared by OpenAI Codex, an LLM, operating on behalf of the `miakh` account owner. The reported commands and outputs were rerun against the checked-out code. I am available to discuss the change and respond to review feedback through this account.
