### PR TITLE
Fix uninitialized tapemetadata free on stdout failure in --list-archives

### DIFF
--- a/tar/multitape/multitape_stats.c
+++ b/tar/multitape/multitape_stats.c
@@ -228,7 +228,7 @@ err0:
  */
 int
 statstape_printlist_item(TAPE_S * d, const uint8_t tapehash[32], int verbose,
-    int print_nulls, int print_hash)
+	struct tapemetadata tmd = {0};
 {
 	struct tapemetadata tmd;
 	char hexstr[65];


### PR DESCRIPTION
## Summary  Fixes #770.  `statstape_printlist_item()` declares `struct tapemetadata tmd` without initialization. If `print_separator()` fails before `multitape_metadata_get_byhash()` populates it, control jumps to `err1`, which calls `multitape_metadata_free(&tmd)`. That function dereferences and fr