### PR TITLE
util: size the safe_fprintf() flush reserve for multibyte input

### DIFF
--- a/tar/util.c
+++ b/tar/util.c
@@ -169,8 +169,14 @@ safe_fprintf(FILE *f, const char *fmt, ...)
 			try_wc = 0;
 		}
 
-		/* If our output buffer is full, dump it and keep going. */
-		if (i > (sizeof(outbuff) - 20)) {
+		/*
+		 * If the buffer might not have room for the worst-case
+		 * expansion of the next character -- bsdtar_expand_char()
+		 * can emit four bytes per input byte, and sprintf() adds a
+		 * terminating '\0' after the last of them -- dump it
+		 * and keep going.
+		 */
+		if (i > (sizeof(outbuff) - (4 * (size_t)MB_CUR_MAX + 1))) {
 			outbuff[i++] = '\0';
 			fprintf(f, "%s", outbuff);
 			i = 0;

--- a/tests/regressions/pr822/README.md
+++ b/tests/regressions/pr822/README.md
@@ -1,0 +1,58 @@
+# PR822: real-glibc affected-function regression
+
+This is executable validation for the existing [PR822](https://github.com/Tarsnap/tarsnap/pull/822) / [report821](https://github.com/Tarsnap/tarsnap/issues/821), not a new report or bounty claim. C/Claude authored the report and production fix. FLINT supplied the real-glibc reproduction and original 72-outcome boundary matrix. QUAY packaged that handoff, added ordinary-output and input/source checks, and executed this package on September 8, 2026. QUAY is an LLM assistant acting for the existing operator and can respond to review in an active session; no unattended monitoring is implied.
+
+## Source and execution scope
+
+The runner verifies the entire candidate `tar/util.c` Git blob before extracting its unchanged `safe_fprintf()` and `bsdtar_expand_char()` bodies. It reconstructs the original file by reversing the exact production hunk, then verifies the entire original Git blob. An optional `--baseline` file must match that original byte for byte. The actual function bodies, rather than a rewritten implementation, are compiled into a standalone driver with the real libc conversion functions. The source license notice is retained in generated C files.
+
+| Input | Identity |
+| --- | --- |
+| Original upstream commit | `0bf0b299fed91139044c81cc6fcdc5521c34d235` |
+| Original `tar/util.c` blob | `e16564560086441ccbc7f7beade122b1ac115bc2` |
+| Original PR822 implementation commit | `1f8bfe09c243502263889aede1790ba39fc9a2bf` |
+| Fixed `tar/util.c` blob | `16bf2f878d1eda209d41054060e75b6d16b05adf` |
+| Published runner blob | `2b0e238b0de624c62182edae684ad40e8177a477` |
+| Published driver blob | `165ce4f6f5cb2920243cfe1ef56815dd70b07449` |
+
+No production file is changed by this validation. No archive, Tarsnap account, network request, credentials, server, or full client invocation is used. This proves affected-function behavior, not full CLI/archive reachability, exploitability, other libc behavior, a payment, or upstream acceptance.
+
+## Reproduce
+
+Requires GNU/Linux with glibc, Python 3.10+, GCC or Clang, and AddressSanitizer. From this PR checkout:
+
+```sh
+python3 tests/regressions/pr822/run.py --cc gcc --opt 1
+python3 tests/regressions/pr822/run.py --cc clang --opt 1
+python3 tests/regressions/pr822/run.py --cc gcc --opt 2
+python3 tests/regressions/pr822/run.py --cc clang --opt 2
+```
+
+Each call uses a fresh temporary evidence directory. `--output /path/to/new-directory` selects a directory that must not already exist; `--source /path/to/util.c` selects an exact copy of the fixed source. All subprocess stdout/stderr, generated C, binaries, compiler version, commands, and per-case outcomes are retained. The `summary.json` result is authoritative for this runner; no pass is inferred from mere completion.
+
+Exit 0 means all 88 declared outcomes match. Exit 77 means the actual locale/converter prerequisite is unavailable and the result is `SKIP_PREREQUISITE`, not PASS. Build failures, unexpected signals, wrong output, source drift, and unexpected sanitizer outcomes fail. Each child has a timeout. No sanitizer report is suppressed; the six expected original faults must contain `AddressSanitizer: stack-buffer-overflow` and exit 97. Leak detection is disabled because this test targets the stack boundary, not leaks. Non-PIE test executables provide a fixed address layout; ASan instrumentation remains enabled.
+
+[AddressSanitizer usage documentation](https://clang.llvm.org/docs/AddressSanitizer.html) describes the compile/link instrumentation and frame-pointer flags. This package does not alter or disable the application's normal checks.
+
+## Measured results
+
+Local isolated x86-64 cloud runtime: glibc 2.41, `C.UTF-8`, `MB_CUR_MAX=6`, `MB_LEN_MAX=16`; GCC 14.2.0 (Debian 14.2.0-19) and Clang 17.0.0. This is local execution, not a hosted CI result.
+
+The real converter returns 4/5/6 for the three respective non-printable byte sequences; the driver records that prerequisite in each process. FLINT's original observation therefore carries forward: a blanket claim that this glibc UTF-8 converter rejects all sequences longer than four bytes is incorrect in this measured environment. This is not a claim about Unicode scalar validity or all libc versions.
+
+| Configuration | Declared outcomes matched | Original overflow inputs | Fixed exact-output calls |
+| --- | ---: | ---: | ---: |
+| GCC `-O1` + ASan | 88/88 | 6 | 44/44 |
+| GCC `-O2` + ASan | 88/88 | 6 | 44/44 |
+| Clang `-O1` + ASan | 88/88 | 6 | 44/44 |
+| Clang `-O2` + ASan | 88/88 | 6 | 44/44 |
+
+Total: 352 matched expectations, not 352 distinct tests. They are 88 expectations repeated under four compiler/optimization configurations: 72 boundary outcomes plus 16 ordinary-output controls per configuration. There are 24 expected original ASan terminations across those runs, representing the same six inputs repeated four times. Every one of the 176 fixed-function calls exits 0 and matches exact output.
+
+The boundary matrix uses 12 ASCII-prefix lengths (`0,230,231,232,233,234,235,236,237,255,256,512`), three sequence widths, and both source versions. Original five-byte input fails at prefix236; original six-byte input fails at prefixes232 through236. The four-byte control does not overflow. Fixed output for the original distinguishing example is exactly 236 `A` bytes followed by `\370\210\200\200\200` (256 bytes). Prefixes255/256/512 also exercise heap-backed formatting rather than only stack-backed formatting.
+
+Eight ordinary-output controls per source cover empty/ASCII strings, backslash and named control escaping, printable UTF-8, and byte-wise fallback after an invalid sequence. Two additional source-integrity checks reject altered candidate/baseline files before invoking a compiler. Five driver argument checks reject out-of-range, negative, or trailing-junk arguments with exit64. Python compilation also passes. These seven packaging checks are separate from the352 native expectations.
+
+## Attribution and follow-through
+
+Original FLINT handoff: [source, measurements, and script](https://tokenjunkielabs.slack.com/archives/C0BVANHNB26/p1788736511662909). The original source-only PR description predates that evidence. This directory makes the existing evidence runnable and visible in the same PR without a duplicate issue, new claim, or change to C/Claude's production fix. The original reporter retains bounty credit; no approved amount or payment is asserted. Maintainer review remains pending.

--- a/tests/regressions/pr822/driver.c
+++ b/tests/regressions/pr822/driver.c
@@ -1,0 +1,90 @@
+/*
+ * PR822 affected-function regression driver.
+ * FLINT authored the original real-glibc sequence/prefix reproducer.
+ * QUAY packaged it with a locale probe and ordinary-output controls.
+ * This file is appended to the unmodified, hash-checked function bodies.
+ */
+#include <errno.h>
+#include <limits.h>
+
+static const unsigned char sequences[][7] = {
+	{0xf4, 0x90, 0x80, 0x80, 0, 0, 0},
+	{0xf8, 0x88, 0x80, 0x80, 0x80, 0, 0},
+	{0xfc, 0x84, 0x80, 0x80, 0x80, 0x80, 0}
+};
+
+static int
+probe(void)
+{
+	const char *loc;
+	wchar_t wc;
+	unsigned n;
+	int converted;
+
+	loc = setlocale(LC_ALL, "C.UTF-8");
+	if (loc == NULL)
+		loc = setlocale(LC_ALL, "C.utf8");
+	if (loc == NULL)
+		return (77);
+	fprintf(stderr, "glibc=%s locale=%s MB_CUR_MAX=%zu MB_LEN_MAX=%d\n",
+	    gnu_get_libc_version(), loc, (size_t)MB_CUR_MAX, MB_LEN_MAX);
+	for (n = 4; n <= 6; n++) {
+		wc = 0;
+		mbtowc(NULL, NULL, 0);
+		converted = mbtowc(&wc, (const char *)sequences[n - 4], n);
+		fprintf(stderr, "n=%u converted=%d wc=0x%lx printable=%d\n",
+		    n, converted, (unsigned long)wc, !!iswprint(wc));
+		if (converted != (int)n || iswprint(wc))
+			return (77);
+	}
+	return (0);
+}
+
+static int
+number(const char *text, unsigned long maximum, unsigned *value)
+{
+	char *end;
+	unsigned long parsed;
+
+	if (*text < '0' || *text > '9')
+		return (-1);
+	errno = 0;
+	parsed = strtoul(text, &end, 10);
+	if (errno || *end != '\0' || parsed > maximum)
+		return (-1);
+	*value = (unsigned)parsed;
+	return (0);
+}
+
+int
+main(int argc, char **argv)
+{
+	char input[520];
+	unsigned prefix, n, control;
+	int rc;
+	const char *controls[] = {
+		"", "ordinary ASCII", "\\", "\a\b\f\n\r\t\v",
+		"\xc3\xa9", "\xe2\x82\xac", "\xff\xc3\xa9",
+		"A\n\\\tZ"
+	};
+
+	rc = probe();
+	if (rc != 0)
+		return (rc);
+	if (argc == 2 && strcmp(argv[1], "probe") == 0)
+		return (0);
+	if (argc == 3 && strcmp(argv[1], "control") == 0) {
+		if (number(argv[2], 7, &control) != 0)
+			return (64);
+		safe_fprintf(stdout, "%s", controls[control]);
+		return (ferror(stdout) ? 74 : 0);
+	}
+	if (argc != 3 || number(argv[1], 512, &prefix) != 0 ||
+	    number(argv[2], 6, &n) != 0 || n < 4)
+		return (64);
+	memset(input, 'A', prefix);
+	memcpy(input + prefix, sequences[n - 4], n);
+	input[prefix + n] = '\0';
+	safe_fprintf(stdout, "%s", input);
+	return (ferror(stdout) ? 74 : 0);
+}

--- a/tests/regressions/pr822/run.py
+++ b/tests/regressions/pr822/run.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Run FLINT's source-bound PR822 regression without a client/archive/server.
+
+C/Claude owns report821 and the production fix; FLINT owns the initial actual-
+glibc reproduction and boundary matrix. QUAY packages and executes this runner.
+A missing locale/converter prerequisite exits77 and is never reported as PASS.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+import sys
+import tempfile
+
+BASE_BLOB = "e16564560086441ccbc7f7beade122b1ac115bc2"
+FIXED_BLOB = "16bf2f878d1eda209d41054060e75b6d16b05adf"
+OLD = "\t\t/* If our output buffer is full, dump it and keep going. */\n\t\tif (i > (sizeof(outbuff) - 20)) {"
+NEW = """\t\t/*
+\t\t * If the buffer might not have room for the worst-case
+\t\t * expansion of the next character -- bsdtar_expand_char()
+\t\t * can emit four bytes per input byte, and sprintf() adds a
+\t\t * terminating '\\0' after the last of them -- dump it
+\t\t * and keep going.
+\t\t */
+\t\tif (i > (sizeof(outbuff) - (4 * (size_t)MB_CUR_MAX + 1))) {"""
+HEADERS = """#include <ctype.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wchar.h>
+#include <wctype.h>
+#include <locale.h>
+#include <gnu/libc-version.h>
+static size_t bsdtar_expand_char(char *, size_t, char);
+"""
+PREFIXES = (0, 230, 231, 232, 233, 234, 235, 236, 237, 255, 256, 512)
+SEQUENCES = {4: bytes.fromhex("f4 90 80 80"),
+             5: bytes.fromhex("f8 88 80 80 80"),
+             6: bytes.fromhex("fc 84 80 80 80 80")}
+# These six original failures are FLINT's existing matrix, not newly inferred.
+ORIGINAL_FAILURES = {(236, 5)} | {(prefix, 6) for prefix in range(232, 237)}
+CONTROL_OUTPUTS = (b"", b"ordinary ASCII", b"\\\\", b"\\a\\b\\f\\n\\r\\t\\v",
+                   "é".encode(), "€".encode(), b"\\377\\303\\251", b"A\\n\\\\\\tZ")
+ASAN = "detect_leaks=0:halt_on_error=1:abort_on_error=0:exitcode=97"
+
+
+def blob(data: bytes) -> str:
+    return hashlib.sha1(b"blob " + str(len(data)).encode() + b"\0" + data).hexdigest()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def cores(source: Path, baseline: Path | None) -> tuple[str, str, str]:
+    fixed = source.read_bytes()
+    require(blob(fixed) == FIXED_BLOB, "candidate source blob differs from PR822")
+    text = fixed.decode("utf-8")
+    require(text.count(NEW) == 1, "unique production fix hunk not found")
+    base_text = text.replace(NEW, OLD)
+    require(blob(base_text.encode()) == BASE_BLOB, "reconstructed baseline blob mismatch")
+    if baseline is not None:
+        require(baseline.read_bytes() == base_text.encode(), "supplied baseline differs")
+    start = "void\nsafe_fprintf("
+    stop = "\nstatic void\nbsdtar_vwarnc("
+    require(text.count(start) == 1 and text.count(stop) == 1, "ambiguous source extraction")
+    require(text.index(start) < text.index(stop), "invalid extraction order")
+    begin = text.index(start)
+    notice = text[:text.index('#include "bsdtar_platform.h"')]
+    fixed_core = text[begin:text.index(stop)]
+    base_core = base_text[base_text.index(start):base_text.index(stop)]
+    require(fixed_core.count("\nbsdtar_expand_char(") == 1, "expander body not found")
+    return notice, base_core, fixed_core
+
+
+def execute(command: list[str], env: dict[str, str], out: Path, label: str,
+            timeout: int = 10) -> subprocess.CompletedProcess:
+    result = subprocess.run(command, capture_output=True, env=env, timeout=timeout, check=False)
+    (out / (label + ".stdout")).write_bytes(result.stdout)
+    (out / (label + ".stderr")).write_bytes(result.stderr)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path,
+                        default=Path(__file__).resolve().parents[3] / "tar/util.c")
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--cc", default="cc", help="one compiler executable, not a shell command")
+    parser.add_argument("--opt", choices=("0", "1", "2"), default="1")
+    parser.add_argument("--output", type=Path, help="new evidence directory; must not exist")
+    args = parser.parse_args()
+    out = args.output.resolve() if args.output else Path(tempfile.mkdtemp(prefix="pr822-asan-"))
+    if args.output:
+        out.mkdir(parents=True, exist_ok=False)
+    summary = {"status": "FAIL", "source_blob": FIXED_BLOB, "baseline_blob": BASE_BLOB,
+               "platform": platform.platform(), "asan_options": ASAN, "cases": []}
+    env = dict(os.environ, ASAN_OPTIONS=ASAN)
+    try:
+        notice, original, fixed = cores(args.source, args.baseline)
+        compiler = shutil.which(args.cc)
+        require(compiler is not None, "compiler not found: " + args.cc)
+        version = execute([compiler, "--version"], env, out, "compiler", 30)
+        require(version.returncode == 0, "compiler version query failed")
+        summary["compiler"] = version.stdout.decode(errors="replace").splitlines()[0]
+        summary["source_sha256"] = hashlib.sha256(args.source.read_bytes()).hexdigest()
+        driver = Path(__file__).with_name("driver.c").read_text(encoding="utf-8")
+        summary["driver_sha256"] = hashlib.sha256(driver.encode()).hexdigest()
+        for variant, core in (("original", original), ("fixed", fixed)):
+            cfile = out / (variant + ".c")
+            binary = out / variant
+            cfile.write_text(notice + HEADERS + core + driver, encoding="utf-8")
+            command = [compiler, "-Wall", "-Wextra", "-Werror", "-std=c99", "-g",
+                       "-O" + args.opt, "-fno-omit-frame-pointer", "-fsanitize=address",
+                       "-fno-pie", "-no-pie", str(cfile), "-o", str(binary)]
+            summary.setdefault("build_commands", []).append(command)
+            build = execute(command, env, out, variant + "-build", 60)
+            require(build.returncode == 0, variant + " compilation failed")
+            probe = execute([str(binary), "probe"], env, out, variant + "-probe")
+            summary[variant + "_probe"] = probe.stderr.decode(errors="replace")
+            if probe.returncode == 77:
+                summary["status"] = "SKIP_PREREQUISITE"
+                return 77
+            require(probe.returncode == 0, variant + " locale/sanitizer probe failed")
+            for prefix in PREFIXES:
+                for width, sequence in SEQUENCES.items():
+                    label = f"{variant}-p{prefix}-w{width}"
+                    result = execute([str(binary), str(prefix), str(width)], env, out, label)
+                    overflow = variant == "original" and (prefix, width) in ORIGINAL_FAILURES
+                    expected = b"A" * prefix + b"".join(f"\\{byte:03o}".encode() for byte in sequence)
+                    matched = (result.returncode == 97 and
+                               b"AddressSanitizer: stack-buffer-overflow" in result.stderr) if overflow else (
+                                   result.returncode == 0 and result.stdout == expected and
+                                   b"ERROR: AddressSanitizer" not in result.stderr)
+                    summary["cases"].append({"label": label, "exit": result.returncode,
+                                             "expected": "ASAN_OVERFLOW" if overflow else "EXACT_OUTPUT",
+                                             "matched": matched, "stdout_bytes": len(result.stdout)})
+            for index, expected in enumerate(CONTROL_OUTPUTS):
+                label = f"{variant}-control{index}"
+                result = execute([str(binary), "control", str(index)], env, out, label)
+                matched = result.returncode == 0 and result.stdout == expected
+                summary["cases"].append({"label": label, "exit": result.returncode,
+                                         "expected": "EXACT_OUTPUT", "matched": matched,
+                                         "stdout_bytes": len(result.stdout)})
+        require(len(summary["cases"]) == 88, "incomplete matrix")
+        failures = [case["label"] for case in summary["cases"] if not case["matched"]]
+        require(not failures, "unexpected outcomes: " + ", ".join(failures))
+        summary["status"] = "PASS"
+        summary["matched"] = len(summary["cases"])
+        summary["expected_original_overflows"] = len(ORIGINAL_FAILURES)
+        print("PASS: 72 boundary expectations + 16 output controls; evidence:", out)
+        return 0
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        summary["error"] = str(exc)
+        print("FAIL:", exc, "Evidence:", out, file=sys.stderr)
+        return 1
+    finally:
+        (out / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #821.

## Summary

`safe_fprintf()` flushes its 256-byte stack buffer when fewer than 20 bytes are left,
but a single loop iteration can write up to `4 * MB_CUR_MAX + 1` bytes into it, so the
reserve is only sufficient while `MB_CUR_MAX <= 4`.

At the top of each iteration `i <= 236`. One iteration expands one multibyte character
of `n = mbtowc(&wc, p, length)` bytes, and in the non-printable branch each of those
bytes goes through `bsdtar_expand_char()`, whose `default` case writes a backslash at
`buff[i]` and then `sprintf(buff + i + 1, "%03o", ...)` — three digits plus the
terminating NUL that `sprintf()` appends. Starting at offset `o` that touches
`o .. o + 4` and returns 4, so `n` bytes starting at `i` reach index `i + 4n`:

| `MB_CUR_MAX` | highest index written | |
|---|---|---|
| 4 | 252 | in bounds |
| 5 | 256 | 1 past the end |
| 16 (`MB_LEN_MAX`) | 300 | 45 past the end |

The printable branch copies `n` bytes, so it stays at `i + n <= 252` even at
`MB_LEN_MAX`, and the post-conversion-failure path expands a single byte per iteration
with the guard in between. Only the multibyte non-printable branch exceeds the reserve.

The input is archive-controlled: `list_item_verbose()` and `read.c` pass
`archive_entry_pathname()`, `archive_entry_hardlink()` and `archive_entry_symlink()`
into `safe_fprintf()` on the `tarsnap -tf` and `tarsnap -xv` paths.

## Change

Reserve what the loop can actually produce instead of a fixed 20 bytes.
`<stdlib.h>` is already included at `tar/util.c:54`, so `MB_CUR_MAX` is available and
there is no new include. One file, one hunk.

With the threshold at `sizeof(outbuff) - (4 * MB_CUR_MAX + 1)`, the top-of-iteration
value of `i` is at most that threshold and the highest index written is
`threshold + 4 * MB_CUR_MAX`, which is exactly 255 for every `MB_CUR_MAX` from 1 to 16.
Single-byte locales are unaffected apart from flushing at 251 rather than 236.

## Validation

Source-level only. The patched file differs from `0bf0b29` in this hunk alone, brace
and paren counts balance, and no line exceeds 80 columns at 8-wide tabs; the index
arithmetic was checked for `MB_CUR_MAX` in 1..16. I have **not** compiled or run it,
and as noted in #821 I have not exhibited a locale where `mbtowc()` returns 5 or more
for a non-printable character — glibc's UTF-8 converter rejects sequences longer than
four bytes, and I have not tested the stateful ISO-2022 converters. This fixes a
missing bound rather than a reproduced crash; please treat it as a starting point for
review rather than as tested code.

---

Per `AGENTS.md`: I am an LLM (Claude) working on behalf of the operator of this
account. I am available to discuss the change and to revise it in response to review
feedback. I understand bounties attach to the report rather than to a patch; this PR is
here only to make the fix directly reviewable, and it is entirely fine to take the
change from #821 instead and close this.
