### PR TITLE
ccache: fix two error paths in ccache_write.c

### DIFF
--- a/tar/ccache/ccache_write.c
+++ b/tar/ccache/ccache_write.c
@@ -222,6 +222,10 @@ ccache_write(CCACHE * cache, const char * path)
 		goto err1;
 	}
 
+	/* We have no last-path buffer yet. */
+	W.sbuf = NULL;
+	W.sbuflen = 0;
+
 	/*-
 	 * We make three passes through the cache tree:
 	 * 1. Counting the number of records which will be written to disk.
@@ -254,13 +258,12 @@ ccache_write(CCACHE * cache, const char * path)
 	}
 
 	/* Write the records and suffixes. */
-	W.sbuf = NULL;
-	W.sbuflen = 0;
 	if (patricia_foreach(C->tree, callback_write_rec, &W)) {
 		warnp("Error writing cache to %s", W.s);
 		goto err2;
 	}
 	free(W.sbuf);
+	W.sbuf = NULL;
 
 	/* Write the chunk headers and compressed entry trailers. */
 	if (patricia_foreach(C->tree, callback_write_data, &W)) {
@@ -314,6 +317,7 @@ ccache_write(CCACHE * cache, const char * path)
 	return (0);
 
 err2:
+	free(W.sbuf);
 	if (fclose(W.f))
 		warnp("fclose");
 err1:
@@ -338,7 +342,7 @@ ccache_remove(const char * path)
 	/* Construct the name of the cache file. */
 	if (asprintf(&s, "%s/cache", path) == -1) {
 		warnp("asprintf");
-		goto err1;
+		goto err0;
 	}
 
 	/* Delete the file if it exists. */
@@ -357,7 +361,7 @@ ccache_remove(const char * path)
 
 err1:
 	free(s);
-
+err0:
 	/* Failure! */
 	return (-1);
 }

--- a/tests/regressions/pr830/HOSTED.md
+++ b/tests/regressions/pr830/HOSTED.md
@@ -1,0 +1,83 @@
+# Hosted PR830 validation
+
+Executed 2026-09-08 UTC for existing Tarsnap/tarsnap PR830 and report829.
+C/Claude retains the original report and production-fix credit.
+ASTRA-RELAY-COOLDOWN (ChatGPT, an LLM working for the account operator) added
+execution evidence; this is not a new bounty report or claim.
+
+## Exact execution
+
+Run: https://github.com/woahwhattheheck/tarsnap/actions/runs/34181926340
+Job: https://github.com/woahwhattheheck/tarsnap/actions/runs/34181926340/job/101922593174
+All job steps completed successfully, including exact-byte assertions, configure,
+three compiler/sanitizer runs, independent mutation controls, native build, five
+offline version checks and artifact upload.
+
+The fork-only support workflow is on `ci/astra-pr830-cache-write-20260908`, commit
+`68812bb3edb0eabdbcc8ca10747089b8f6e99ca0`. It checked out contribution commit
+`ddcdf19467fb0e5382fd6c9b991ec30ca71cde46`. That commit adds four test/documentation
+files to the original PR head; no production bytes or peer branch were changed.
+The support workflow is not included in the upstream contribution.
+
+| Executed source/configuration | Passed | Failed |
+| --- | ---: | ---: |
+| Fixed, GCC 11.4 | 113 | 0 |
+| Fixed, Clang 14 | 113 | 0 |
+| Fixed, Clang 14 ASan/UBSan plus automatic-storage pattern | 113 | 0 |
+| Exact pre-fix, GCC | 88 | 25 |
+| Remove error free only, GCC | 89 | 24 |
+| Remove post-free NULL assignment only, GCC | 77 | 36 |
+| Restore remove/asprintf error jump only, GCC | 112 | 1 |
+| Move initialization late, Clang/pattern | 107 | 6 |
+
+The same 113 scenarios are repeated across configurations; they are not 339
+distinct tests. Downloaded JSON matches the local GCC14/Clang17 results. All
+candidate compile commands have empty stderr, and every candidate case records
+zero tracked outstanding allocations, invalid-free attempts and open streams.
+Independent failure signatures distinguish 24 leaked buffers, the remove
+asprintf invalid-free attempt, 36 later double-free attempts and six early
+uninitialized-pointer attempts. Expected return codes and file closure remain
+checked even in deliberately failing controls.
+
+The complete native project built with `make -j2`; all five binaries returned
+`1.0.41-head` for `--version`. This is one full native build and five offline
+smoke checks, not a full `make test`, remote archive test or payment evidence.
+
+## Verified artifact
+
+Artifact: `astra-pr830-validated-34181926340`, ID `10039215082`, 65,557 bytes.
+Downloaded ZIP SHA-256:
+`6675d066889408d8bf39ca08439e7c8afdaffb663be1a122d26ade378387e0a2`.
+The ZIP matches GitHub's digest; all 35 payload files match the internal
+SHA256SUMS. All four test/documentation files match the local executed bytes.
+GitHub reports expiry 2026-09-22T03:00:23Z; committed source and replay commands
+remain available after artifact expiry.
+
+Exact blobs:
+- Production, unchanged: `55f3e58200d435ee5b135740bc4fd83e06b10a36`.
+- Pre-fix production: `e6249385097d40b149b6986b9ff8d6f54982cfb7`.
+- C fixture: `187ee009df35cf441c9387170a082f90ea444723`.
+- Runner: `ac425ca854225d851ba5db43f6d961c7d0a1aad7`.
+- Controls: `74b4d799f8a412ca8a33be32c0654393436e7f90`.
+- Tested README: `c7f1f5514ea412d763501df73605d42ea92cfd19`.
+
+Preparation run34181384442 configured/exported the exact source but failed before
+native build because it attempted to copy make-generated configuration headers
+too early. It is not counted as a passing build. The succeeding full run above
+corrects the step ordering and provides the actual final execution evidence.
+
+## Boundaries and replay
+
+See README.md and the runnable `run.py`/`controls.py` alongside this receipt.
+Production writer, Patricia traversal and stdio are real; allocation/error seams
+and generated records are synthetic. Invalid frees are recorded without passing
+them to libc, and measured baseline leaks are cleaned up after recording.
+Sync seams use local flush/fsync rather than the complete platform helper. Only
+the unchanged Patricia dependency's separately known signed-shift sanitizer is
+excluded; its other checks and all writer/harness sanitizers remain enabled.
+No claim is made about raw baseline sanitizer crashes or crash durability.
+
+No real cache, server, key, credential, owner-PC resource, sponsor message,
+additional report, bounty submission, accepted award, payment or upstream merge
+is part of this validation. PR830 remains with its original reporter/maintainer
+process; evidence is supplied through its existing contribution branch.

--- a/tests/regressions/pr830/README.md
+++ b/tests/regressions/pr830/README.md
@@ -1,0 +1,93 @@
+# PR830 cache-write cleanup regression
+
+This is additive execution evidence for existing Tarsnap/tarsnap PR830 and
+report829. C/Claude authored the report and production correction.
+ASTRA-RELAY-COOLDOWN (ChatGPT, an LLM working for the account operator) supplied
+these tests and can address concrete review feedback in a subsequent session.
+No new bug report, bounty claim, award, payment or upstream merge is asserted.
+
+## Reproduce
+
+Use a configured checkout of the existing `ccache-write-error-paths` branch.
+The runner needs Python3.9+, a C compiler and the project's generated `config.h`.
+For the sanitizer and late-initialization control use Clang14 or newer.
+
+```sh
+autoreconf -i
+./configure
+python3 tests/regressions/pr830/run.py --output /tmp/pr830-gcc.json
+python3 tests/regressions/pr830/run.py --cc clang --output /tmp/pr830-clang.json
+python3 tests/regressions/pr830/run.py --cc clang --sanitize --auto-init-pattern --output /tmp/pr830-sanitized.json
+git show 0bf0b299fed91139044c81cc6fcdc5521c34d235:tar/ccache/ccache_write.c > /tmp/pr830-before.c
+python3 tests/regressions/pr830/controls.py --baseline /tmp/pr830-before.c --output /tmp/pr830-controls
+```
+
+Native integration remains the project's ordinary `make -j2`, followed by
+`--version` for tarsnap, tarsnap-keygen, tarsnap-keymgmt, tarsnap-keyregen and
+tarsnap-recrypt. These commands need no account, server or real archive.
+A native build and version checks are not a full `make test` or live-service test.
+
+## Executed local result
+
+The complete unchanged `tar/ccache/ccache_write.c` translation unit is compiled
+inside the fixture, rather than copied/reimplemented functions. Both
+`ccache_write()` and `ccache_remove()` run against unique temporary directories.
+Real Patricia initialization, insertion and traversal supply records; real stdio
+writes create cache files. An independent reader checks record count, portable
+integer fields, reconstructed prefix/suffix paths, age increment, chunks,
+compressed-trailer bytes and EOF. Empty, all-skipped, mixed and changing path
+lengths are covered.
+
+The same113 scenarios pass with GCC14.2, Clang17 and Clang17 address/undefined
+behavior sanitizers in an isolated Linux runtime. This is113 distinct scenarios,
+not339 independent cases. Every candidate scenario has zero tracked outstanding
+allocations, zero invalid-free attempts and zero open writer streams.
+
+Exact production source:
+- Before: `e6249385097d40b149b6986b9ff8d6f54982cfb7`.
+- Original PR830 fix, unchanged: `55f3e58200d435ee5b135740bc4fd83e06b10a36`.
+
+The exact pre-fix source fails25 scenarios:24 leaked path buffers and one invalid
+free attempt on the remove/asprintf failure. Independent controls distinguish:
+
+| Control | Failed scenarios | Retained buffers | Invalid-free attempts |
+| --- | ---: | ---: | ---: |
+| Remove error-path buffer free only | 24 | 24 | 0 |
+| Remove the post-free NULL assignment only | 36 | 0 | 36 |
+| Restore the old remove/asprintf jump only | 1 | 0 | 1 |
+| Move initialization back to the late location | 6 | 0 | 6 |
+
+The last control uses Clang's automatic-storage pattern initialization to make
+uninitialized pointer use deterministic. It does not alter production source
+beyond relocating the actual initialization. `controls.py` checks each exact
+failure count and requires preserved return codes, file closure and expected
+contents, rather than accepting any arbitrary process failure as proof.
+
+## Fault and sanitizer boundaries
+
+Allocation and stdio/traversal fault seams are synthetic: injected asprintf,
+fopen, malloc, record/count/data traversal, fwrite, flush/sync, fclose, unlink,
+rename and directory-sync failures. Successful callbacks, portable encoding and
+writer cleanup execute actual production code. The sync seams use local
+fflush/fsync and a directory descriptor, not the full platform helper; the
+ordinary native build checks linkage separately. No crash-durability claim is
+made, and the separate unlink-before-rename behavior is not repaired here.
+
+For asprintf failure, the output pointer is deliberately set to a nonheap sentinel
+instead of relying on incidental stack contents. Its failure output is not a
+usable allocation. The free seam records an invalid/double-free attempt without
+passing it to libc; retained baseline allocations are counted before controlled
+cleanup. These are bounded ownership witnesses, not a claimed observed glibc
+crash or a raw LeakSanitizer report of the original source.
+
+The unchanged Patricia dependency contains the separately reported signed-shift
+issue addressed by PR862. Only its dependency-object shift sanitizer is disabled;
+its address/other undefined checks and all writer/harness checks remain enabled.
+No production source is changed to compose that separate fix.
+
+Every scenario runs in a bounded subprocess and uses only generated records and
+its own temporary cache files. No network request, real key, live cache, owner-PC
+operation, sponsor notification or credential is used. JSON retains source hashes,
+compiler commands, per-scenario results and exact diagnostic counts. The finite
+verification workflow remains on a fork-only support branch, outside this PR.
+Hosted validation and artifact receipts are recorded separately after execution.

--- a/tests/regressions/pr830/cache_write.c
+++ b/tests/regressions/pr830/cache_write.c
@@ -1,0 +1,316 @@
+/* PR830 regression: real writer + Patricia + stdio, bounded local fault seams. */
+#include "platform.h"
+#include <sys/stat.h>
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include "asprintf.h"
+#include "ccache_internal.h"
+#include "dirutil.h"
+#include "fileutil.h"
+#include "multitape_internal.h"
+#include "patricia.h"
+#include "sysendian.h"
+#include "warnp.h"
+#include "ccache.h"
+
+static void * checked_malloc(size_t);
+static void checked_free(void *);
+static int checked_asprintf(char **, const char *, ...);
+static FILE * checked_fopen(const char *, const char *);
+static int checked_fclose(FILE *);
+static size_t checked_fwrite(const void *, size_t, size_t, FILE *);
+static int checked_foreach(PATRICIA *, int (*)(void *, uint8_t *, size_t, void *), void *);
+static int checked_fsync(FILE *, const char *);
+static int checked_dirsync(const char *);
+static int checked_unlink(const char *);
+static int checked_rename(const char *, const char *);
+static void quiet_warning(const char *, ...);
+
+#undef asprintf
+#undef warnp
+#undef warn0
+#define malloc checked_malloc
+#define free checked_free
+#define asprintf checked_asprintf
+#define fopen checked_fopen
+#define fclose checked_fclose
+#define fwrite checked_fwrite
+#define patricia_foreach checked_foreach
+#define fileutil_fsync checked_fsync
+#define dirutil_fsyncdir checked_dirsync
+#define unlink checked_unlink
+#define rename checked_rename
+#define warnp quiet_warning
+#define warn0 quiet_warning
+#ifndef CCACHE_SOURCE
+#define CCACHE_SOURCE "../../../tar/ccache/ccache_write.c"
+#endif
+#include CCACHE_SOURCE
+#undef malloc
+#undef free
+#undef asprintf
+#undef fopen
+#undef fclose
+#undef fwrite
+#undef patricia_foreach
+#undef fileutil_fsync
+#undef dirutil_fsyncdir
+#undef unlink
+#undef rename
+#undef warnp
+#undef warn0
+
+struct allocation { void * ptr; int live; int buffer; };
+static struct allocation allocations[64];
+static size_t used;
+static int invalid_frees, files_open, printf_calls, malloc_calls;
+static int write_calls, close_calls, walk_calls, buffer_frees;
+static const char * scenario;
+static int parameter;
+static char poison; /* asprintf failure may leave an unspecified output value. */
+
+static int is(const char * name) { return strcmp(scenario, name) == 0; }
+static void quiet_warning(const char * fmt, ...) { (void)fmt; }
+static void * track(size_t size, int buffer) {
+    void * p = malloc(size ? size : 1);
+    if (p == NULL || used == sizeof(allocations) / sizeof(allocations[0]))
+        exit(70);
+    allocations[used++] = (struct allocation){p, 1, buffer};
+    return p;
+}
+static void * checked_malloc(size_t size) {
+    malloc_calls++;
+    if (is("malloc") && malloc_calls == parameter) {
+        errno = ENOMEM;
+        return NULL;
+    }
+    return track(size, 1);
+}
+static void checked_free(void * p) {
+    size_t i;
+    if (p == NULL) return;
+    for (i = used; i > 0; i--) {
+        if (allocations[i - 1].live && allocations[i - 1].ptr == p) {
+            allocations[i - 1].live = 0;
+            buffer_frees += allocations[i - 1].buffer;
+            free(p);
+            return;
+        }
+    }
+    /* Record an invalid/double free without invoking undefined libc behavior. */
+    invalid_frees++;
+}
+static int checked_asprintf(char ** out, const char * fmt, ...) {
+    va_list ap, copy;
+    int n;
+    printf_calls++;
+    if ((is("asprintf") && printf_calls == parameter) || is("remove-asprintf")) {
+        *out = &poison;
+        errno = ENOMEM;
+        return -1;
+    }
+    va_start(ap, fmt);
+    va_copy(copy, ap);
+    n = vsnprintf(NULL, 0, fmt, copy);
+    va_end(copy);
+    if (n < 0) exit(70);
+    *out = track((size_t)n + 1, 0);
+    if (vsnprintf(*out, (size_t)n + 1, fmt, ap) != n) exit(70);
+    va_end(ap);
+    return n;
+}
+static FILE * checked_fopen(const char * path, const char * mode) {
+    FILE * f;
+    if (is("fopen")) { errno = EACCES; return NULL; }
+    f = fopen(path, mode);
+    if (f != NULL) files_open++;
+    return f;
+}
+static int checked_fclose(FILE * f) {
+    int rc = fclose(f);
+    files_open--;
+    close_calls++;
+    if (is("fclose") && close_calls == 1) { errno = EIO; return EOF; }
+    return rc;
+}
+static size_t checked_fwrite(const void * p, size_t size, size_t count, FILE * f) {
+    write_calls++;
+    if (is("fwrite") && write_calls == parameter) { errno = ENOSPC; return 0; }
+    return fwrite(p, size, count, f);
+}
+struct walk_context {
+    int (*callback)(void *, uint8_t *, size_t, void *);
+    void * cookie;
+    int pass, seen;
+};
+static int walk_one(void * v, uint8_t * key, size_t len, void * rec) {
+    struct walk_context * w = v;
+    int rc = w->callback(w->cookie, key, len, rec);
+    w->seen++;
+    if (rc) return rc;
+    if ((is("record-after") && w->pass == 2 && w->seen == parameter) ||
+        (is("data-after") && w->pass == 3 && w->seen == parameter)) {
+        errno = EIO;
+        return -1;
+    }
+    return 0;
+}
+static int checked_foreach(PATRICIA * tree,
+    int (*callback)(void *, uint8_t *, size_t, void *), void * cookie) {
+    struct walk_context w = {callback, cookie, ++walk_calls, 0};
+    if ((is("count") && w.pass == 1) ||
+        (is("record-before") && w.pass == 2) ||
+        (is("data-before") && w.pass == 3)) { errno = EIO; return -1; }
+    return patricia_foreach(tree, walk_one, &w);
+}
+static int checked_fsync(FILE * f, const char * path) {
+    (void)path;
+    if (is("fsync")) { errno = EIO; return -1; }
+    return fflush(f) || fsync(fileno(f)) ? -1 : 0;
+}
+static int checked_dirsync(const char * path) {
+    int fd, rc;
+    if (is("dirsync")) { errno = EIO; return -1; }
+    if ((fd = open(path, O_RDONLY | O_DIRECTORY)) == -1) return -1;
+    rc = fsync(fd);
+    if (close(fd)) rc = -1;
+    return rc;
+}
+static int checked_unlink(const char * path) {
+    if (is("unlink") || is("remove-unlink")) { errno = EACCES; return -1; }
+    return unlink(path);
+}
+static int checked_rename(const char * from, const char * to) {
+    if (is("rename")) { errno = EIO; return -1; }
+    return rename(from, to);
+}
+
+#define RECORDS 6
+static struct ccache_record records[RECORDS];
+static struct chunkheader chunks[RECORDS];
+static uint8_t trailers[RECORDS][3];
+static char keys[RECORDS][256];
+static int active[RECORDS];
+static const size_t lengths[RECORDS] = {12, 80, 20, 140, 30, 200};
+static void make_tree(struct ccache_internal * cache, int n) {
+    int i, j;
+    if ((cache->tree = patricia_init()) == NULL) exit(70);
+    for (i = 0; i < n; i++) {
+        memset(keys[i], 'x', lengths[i]);
+        snprintf(keys[i], 8, "root/%d-", i);
+        keys[i][7] = 'x';
+        keys[i][lengths[i]] = 0;
+        records[i].ino = (ino_t)(100 + i);
+        records[i].size = 1000 + i;
+        records[i].mtime = 1700000000 + i;
+        records[i].nch = 1;
+        records[i].tlen = records[i].tzlen = 3;
+        records[i].age = i;
+        memset(&chunks[i], i + 1, sizeof(chunks[i]));
+        for (j = 0; j < 3; j++) trailers[i][j] = (uint8_t)(i + j + 50);
+        records[i].chp = &chunks[i];
+        records[i].ztrailer = trailers[i];
+        active[i] = 1;
+        if (is("skipped") || (is("mixed") && i % 2 == 0)) {
+            active[i] = 0;
+            if (i % 3 == 0) records[i].nch = records[i].tlen = 0;
+            else if (i % 3 == 1) records[i].age = MAXAGE + 1;
+            else records[i].mtime = -1;
+        }
+        if (patricia_insert(cache->tree, (uint8_t *)keys[i], strlen(keys[i]), &records[i])) exit(70);
+    }
+}
+static int verify_file(const char * path, int n) {
+    FILE * f = fopen(path, "rb");
+    uint8_t count[4], payload[sizeof(struct chunkheader)];
+    struct ccache_record_external ext;
+    char previous[256] = "", current[256];
+    size_t plen, slen;
+    int i, expected = 0, ok = 1;
+    if (!f) return 0;
+    for (i = 0; i < n; i++) expected += active[i];
+    if (fread(count, 4, 1, f) != 1 || le32dec(count) != (uint32_t)expected) ok = 0;
+    for (i = 0; i < n && ok; i++) {
+        if (!active[i]) continue;
+        if (fread(&ext, sizeof(ext), 1, f) != 1) { ok = 0; break; }
+        plen = le32dec(ext.prefixlen); slen = le32dec(ext.suffixlen);
+        if (plen > strlen(previous) || plen + slen >= sizeof(current)) { ok = 0; break; }
+        memcpy(current, previous, plen);
+        if (fread(current + plen, 1, slen, f) != slen) { ok = 0; break; }
+        current[plen + slen] = 0;
+        if (strcmp(current, keys[i]) || le64dec(ext.ino) != (uint64_t)records[i].ino ||
+            le64dec(ext.size) != (uint64_t)records[i].size ||
+            le64dec(ext.mtime) != (uint64_t)records[i].mtime || le64dec(ext.nch) != 1 ||
+            le32dec(ext.tlen) != 3 || le32dec(ext.tzlen) != 3 ||
+            le32dec(ext.age) != (uint32_t)records[i].age + 1) ok = 0;
+        strcpy(previous, current);
+    }
+    for (i = 0; i < n && ok; i++) {
+        if (!active[i]) continue;
+        if (fread(payload, sizeof(chunks[i]), 1, f) != 1 || memcmp(payload, &chunks[i], sizeof(chunks[i]))) ok = 0;
+        if (fread(payload, 3, 1, f) != 1 || memcmp(payload, trailers[i], 3)) ok = 0;
+    }
+    if (ok && fgetc(f) != EOF) ok = 0;
+    fclose(f);
+    return ok;
+}
+static int is_old_file(const char * path) {
+    FILE * f = fopen(path, "rb");
+    char b[16] = {0};
+    int ok;
+    if (!f) return 0;
+    ok = fread(b, 1, sizeof(b), f) == 8 && memcmp(b, "oldcache", 8) == 0;
+    fclose(f);
+    return ok;
+}
+int main(int argc, char ** argv) {
+    struct ccache_internal cache = {0};
+    char directory[] = "/tmp/tarsnap-pr830-XXXXXX", path[256], temp[256];
+    FILE * old;
+    int n, rc, expected, content_ok = 1, old_ok, live = 0, buffers = 0, passed, remove_mode;
+    size_t i;
+    if (argc != 4) return 64;
+    scenario = argv[1]; n = atoi(argv[2]); parameter = atoi(argv[3]);
+    if (n < 0 || n > RECORDS || mkdtemp(directory) == NULL) return 70;
+    snprintf(path, sizeof(path), "%s/cache", directory);
+    snprintf(temp, sizeof(temp), "%s/cache.new", directory);
+    if ((old = fopen(path, "wb")) == NULL) return 70;
+    if (fwrite("oldcache", 8, 1, old) != 1 || fclose(old)) return 70;
+    remove_mode = strncmp(scenario, "remove-", 7) == 0;
+    expected = (is("success") || is("empty") || is("mixed") || is("skipped") ||
+                is("remove-existing") || is("remove-missing")) ? 0 : -1;
+    if (is("remove-missing") && unlink(path)) return 70;
+    if (remove_mode) {
+        rc = ccache_remove(directory);
+        content_ok = rc == 0 ? access(path, F_OK) == -1 : is_old_file(path);
+    } else {
+        make_tree(&cache, n);
+        rc = ccache_write(&cache, directory);
+        if (expected == 0) content_ok = verify_file(path, n);
+        else if (!is("rename") && !is("dirsync")) content_ok = is_old_file(path);
+        /* Existing unlink-before-rename behavior is outside PR830. */
+        patricia_free(cache.tree);
+    }
+    old_ok = is_old_file(path);
+    for (i = 0; i < used; i++) if (allocations[i].live) { live++; buffers += allocations[i].buffer; }
+    passed = rc == expected && !live && !invalid_frees && !files_open && content_ok;
+    printf("{\"scenario\":\"%s\",\"records\":%d,\"parameter\":%d,\"result\":%d,"
+           "\"expected_result\":%d,\"live_allocations\":%d,\"live_buffers\":%d,"
+           "\"invalid_frees\":%d,\"open_files\":%d,\"write_calls\":%d,"
+           "\"walk_calls\":%d,\"buffer_allocations\":%d,\"buffer_frees\":%d,"
+           "\"content_ok\":%s,\"old_cache_present\":%s,\"passed\":%s}\n",
+           scenario, n, parameter, rc, expected, live, buffers, invalid_frees, files_open,
+           write_calls, walk_calls, malloc_calls, buffer_frees, content_ok ? "true" : "false",
+           old_ok ? "true" : "false", passed ? "true" : "false");
+    /* Release measured baseline leaks after recording, keeping repeated runs bounded. */
+    for (i = 0; i < used; i++) if (allocations[i].live) free(allocations[i].ptr);
+    unlink(path); unlink(temp); rmdir(directory);
+    return passed ? 0 : 1;
+}

--- a/tests/regressions/pr830/controls.py
+++ b/tests/regressions/pr830/controls.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Verify exact pre-fix failure and each independent PR830 cleanup requirement."""
+from __future__ import annotations
+import argparse
+import json
+from pathlib import Path
+import subprocess
+from run import blob
+
+FIXED = "55f3e58200d435ee5b135740bc4fd83e06b10a36"
+BASELINE = "e6249385097d40b149b6986b9ff8d6f54982cfb7"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[3])
+    args = parser.parse_args()
+    root, output = args.root.resolve(), args.output.resolve()
+    source_path = root / "tar/ccache/ccache_write.c"
+    assert blob(source_path) == FIXED, "unexpected candidate source"
+    assert blob(args.baseline) == BASELINE, "unexpected pre-fix source"
+    output.mkdir(parents=True, exist_ok=True)
+    source = source_path.read_text()
+    route = 'if (asprintf(&s, "%s/cache", path) == -1) {\n\t\twarnp("asprintf");\n\t\tgoto err0;'
+    init = '\t/* We have no last-path buffer yet. */\n\tW.sbuf = NULL;\n\tW.sbuflen = 0;\n\n'
+    error_free = 'err2:\n\tfree(W.sbuf);'
+    reset = '\tfree(W.sbuf);\n\tW.sbuf = NULL;'
+    assert all(source.count(text) == 1 for text in (route, init, error_free, reset))
+    variants = {
+        "baseline": args.baseline.read_text(),
+        "no-error-free": source.replace(error_free, 'err2:'),
+        "no-reset": source.replace(reset, '\tfree(W.sbuf);'),
+        "remove-old-route": source.replace(route, route.replace('goto err0;', 'goto err1;')),
+        "late-init": source.replace(init, '').replace('\t/* Write the records and suffixes. */\n',
+                         '\t/* Write the records and suffixes. */\n\tW.sbuf = NULL;\n\tW.sbuflen = 0;\n'),
+    }
+    expected = {"baseline": (25, 24, 1), "no-error-free": (24, 24, 0),
+                "no-reset": (36, 0, 36), "remove-old-route": (1, 0, 1), "late-init": (6, 0, 6)}
+    summaries = []
+    runner = Path(__file__).with_name("run.py")
+    for name, text in variants.items():
+        target = output / (name + '.c')
+        target.write_text(text)
+        report_path = output / (name + '.json')
+        command = ['python3', str(runner), '--root', str(root), '--source', str(target), '--output', str(report_path)]
+        if name == 'late-init':
+            command += ['--cc', 'clang', '--auto-init-pattern']
+        result = subprocess.run(command, capture_output=True, text=True, timeout=120)
+        (output / (name + '.log')).write_text(result.stdout + result.stderr)
+        assert result.returncode == 1, (name, result.returncode, result.stdout, result.stderr)
+        report = json.loads(report_path.read_text())
+        assert report['cases'] == 113 and report['source_blob'] == blob(target)
+        failed = [row for row in report['results'] if not row['passed']]
+        actual = (len(failed), sum(row['live_buffers'] for row in failed),
+                  sum(row['invalid_frees'] for row in failed))
+        assert actual == expected[name], (name, actual, expected[name])
+        assert all(row['exit_code'] == 1 and row['result'] == row['expected_result'] and
+                   row['open_files'] == 0 and row['content_ok'] and not row['stderr'] for row in failed)
+        summaries.append({'variant': name, 'source_blob': blob(target), 'failures': actual[0],
+                          'leaked_buffers': actual[1], 'invalid_free_attempts': actual[2]})
+    (output / 'controls-summary.json').write_text(json.dumps(summaries, indent=2) + '\n')
+    print(json.dumps(summaries))
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/regressions/pr830/run.py
+++ b/tests/regressions/pr830/run.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Compile the complete PR830 writer and exercise only disposable local caches."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def blob(path: Path) -> str:
+    data = path.read_bytes()
+    return hashlib.sha1(b"blob " + str(len(data)).encode() + b"\0" + data).hexdigest()
+
+
+def scenarios() -> list[tuple[str, int, int]]:
+    rows = [("empty", 0, 0), ("skipped", 6, 0), ("mixed", 6, 0)]
+    for count in (1, 3, 6):
+        rows += [(name, count, 0) for name in (
+            "success", "fopen", "count", "record-before", "data-before",
+            "fsync", "fclose", "unlink", "rename", "dirsync")]
+        rows += [("asprintf", count, i) for i in (1, 2)]
+        rows += [(name, count, i) for name in ("record-after", "data-after")
+                 for i in range(1, count + 1)]
+        rows += [("fwrite", count, i) for i in range(1, 4 * count + 2)]
+        rows += [("malloc", count, i) for i in range(1, {1: 1, 3: 2, 6: 4}[count] + 1)]
+    rows += [(name, 0, 0) for name in (
+        "remove-existing", "remove-missing", "remove-asprintf", "remove-unlink")]
+    assert len(rows) == len(set(rows))
+    return rows
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cc", default=os.environ.get("CC", "cc"))
+    parser.add_argument("--source", type=Path)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[3])
+    parser.add_argument("--sanitize", action="store_true")
+    parser.add_argument("--auto-init-pattern", action="store_true", help="Compiler-initialize automatic storage for the late-init mutation control")
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    root = args.root.resolve()
+    source = (args.source or root / "tar/ccache/ccache_write.c").resolve()
+    fixture = Path(__file__).with_name("cache_write.c").resolve()
+    if not (root / "config.h").is_file():
+        parser.error("configure the source checkout first (autoreconf -i && ./configure)")
+    flags = ["-std=c99", "-D_GNU_SOURCE", "-DHAVE_CONFIG_H", "-O1", "-g",
+             "-Wall", "-Wextra", "-fno-omit-frame-pointer", "-I" + str(root)]
+    include_dirs = sorted({path.parent for folder in ("tar", "lib", "lib-platform", "libcperciva", "libarchive")
+                           for path in (root / folder).rglob("*.h")})
+    flags += ["-I" + str(path) for path in include_dirs]
+    if args.auto_init_pattern:
+        flags += ["-ftrivial-auto-var-init=pattern"]
+    if args.sanitize:
+        flags += ["-fsanitize=address,undefined", "-fno-sanitize-recover=all"]
+    report = {"source_blob": blob(source), "fixture_blob": blob(fixture),
+              "runner_blob": blob(Path(__file__)), "patricia_blob": blob(root / "lib/datastruct/patricia.c"),
+              "compiler": subprocess.check_output([args.cc, "--version"], text=True).splitlines()[0],
+              "sanitize": args.sanitize, "auto_init_pattern": args.auto_init_pattern, "commands": [], "results": []}
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="pr830-build-") as directory:
+        work = Path(directory)
+        patricia = work / "patricia.o"
+        binary = work / "cache-write"
+        # PR862 separately fixes old Patricia signed shifts. Keep its unchanged
+        # source and disable ONLY shift checks in this dependency object; retain
+        # its address/other UB checks and ALL writer/harness sanitizers.
+        dep_flags = flags + (["-fno-sanitize=shift"] if args.sanitize else [])
+        commands = [
+            [args.cc, *dep_flags, "-c", str(root / "lib/datastruct/patricia.c"), "-o", str(patricia)],
+            [args.cc, *flags, '-DCCACHE_SOURCE="' + str(source) + '"', str(fixture), str(patricia), "-o", str(binary)],
+        ]
+        for command in commands:
+            result = subprocess.run(command, capture_output=True, text=True, timeout=90)
+            report["commands"].append({"argv": command, "exit_code": result.returncode,
+                                       "stdout": result.stdout, "stderr": result.stderr})
+            if result.returncode:
+                report["status"] = "COMPILE_ERROR"
+                args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+                print(result.stderr)
+                return 2
+        env = {**os.environ, "ASAN_OPTIONS": "detect_leaks=1:halt_on_error=1",
+               "UBSAN_OPTIONS": "halt_on_error=1:print_stacktrace=1"}
+        for name, count, parameter in scenarios():
+            try:
+                result = subprocess.run([str(binary), name, str(count), str(parameter)],
+                                        text=True, capture_output=True, timeout=10, env=env)
+                row = json.loads(result.stdout)
+                row.update(exit_code=result.returncode, stderr=result.stderr)
+                row["passed"] = bool(row.get("passed")) and result.returncode == 0 and not result.stderr
+            except (ValueError, subprocess.TimeoutExpired) as exc:
+                row = {"scenario": name, "records": count, "parameter": parameter, "passed": False,
+                       "error": type(exc).__name__}
+                if isinstance(exc, ValueError):
+                    row.update(exit_code=result.returncode, stdout=result.stdout, stderr=result.stderr)
+            report["results"].append(row)
+    report["cases"] = len(report["results"])
+    report["passed"] = sum(row["passed"] for row in report["results"])
+    report["failed"] = report["cases"] - report["passed"]
+    report["status"] = "PASS" if not report["failed"] else "FAIL"
+    args.output.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({key: report[key] for key in ("status", "cases", "passed", "failed", "source_blob", "compiler")}))
+    return 0 if not report["failed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #829.

## Summary

Two independent error-path defects in `tar/ccache/ccache_write.c`.

**`ccache_remove()` freed an uninitialised pointer.** `s` is declared without an
initialiser, and the `asprintf()` failure path jumped to `err1`, which frees it. glibc
assigns through `asprintf()`'s first argument only on success — its man page states the
contents of `strp` are undefined on failure — so that freed whatever was on the stack.
`ccache_write()` handles the identical case correctly at `:214-217` by jumping to `err0`,
which does not free; `ccache_remove()` simply had no `err0` label.

**`ccache_write()` leaked `W.sbuf`.** `callback_write_rec()` allocates it at `:144`. When
the record-writing traversal fails, `goto err2` closes the file and frees `W.s` but never
`W.sbuf`.

## Change

`free(W.sbuf)` could not just be added to `err2`: that label is also reached from `:239`,
`:246` and `:253`, which run before `W.sbuf` was initialised at `:257` — adding the free
alone would have reproduced the first defect inside the second function. So the fix

- moves the `W.sbuf` / `W.sbuflen` initialisation above the first `goto err2`,
- clears `W.sbuf` after the mid-function `free()` so a later `goto err2` from the
  chunk-header pass cannot double-free,
- releases `W.sbuf` in `err2`,
- gives `ccache_remove()` the missing `err0` label.

One file. No behaviour change on the success path.

## Relationship to other open items

Distinct from #817, which concerns `ccache_write()` unlinking the old cache before the
rename at `:287-301` — a different defect in the same function, on lines this PR does not
touch, so the two do not conflict. Distinct from #825 / PR #826 and #827 / PR #828, which
are in `tar/write.c`.

## Validation

Source-level only. The patched file differs from `0bf0b29` in these five hunks, brace and
paren counts balance, and no line exceeds 80 columns at 8-wide tabs. I have not compiled
or run it, and I have not forced an `asprintf()` or `patricia_foreach()` failure to
observe either path; as stated in #829 the change rests on `s` having no initialiser,
glibc's documented failure behaviour, and the allocation in `callback_write_rec()`.

---

Per `AGENTS.md`: I am an LLM (Claude) working on behalf of the operator of this account.
I am available to discuss the change and to revise it in response to review feedback. I
understand bounties attach to the report rather than to a patch; this PR is here only to
make the fix directly reviewable, and it is entirely fine to take the change from #829
instead and close this.
