### PR TITLE
ccache: fix a leaked record and a zero-length read in ccache_read()

### DIFF
--- a/tar/ccache/ccache_read.c
+++ b/tar/ccache/ccache_read.c
@@ -267,8 +267,10 @@ ccache_read(const char * path)
 	for (i = 0; i < R.N; i++) {
 		if ((ccr = read_rec(&R)) == NULL)
 			goto err5;
-		if (patricia_insert(C->tree, R.sbuf, R.slen, ccr))
+		if (patricia_insert(C->tree, R.sbuf, R.slen, ccr)) {
+			free(ccr);
 			goto err5;
+		}
 		C->chunksusage += ccr->nch * sizeof(struct chunkheader);
 		C->trailerusage += ccr->tzlen;
 	}
@@ -313,7 +315,8 @@ ccache_read(const char * path)
 	C->datalen = R.datalen;
 	if (((C->data = malloc(C->datalen)) == NULL) && (C->datalen > 0))
 		goto err5;
-	if (fread(C->data, C->datalen, 1, R.f) != 1) {
+	if ((C->datalen > 0) &&
+	    (fread(C->data, C->datalen, 1, R.f) != 1)) {
 		warnp("fread(%s)", R.s);
 		goto err6;
 	}

--- a/tests/regressions/pr832/README.md
+++ b/tests/regressions/pr832/README.md
@@ -1,0 +1,162 @@
+# PR832: native cache-reader regression
+
+Operation: `astra-quay-ccache-read-832-20260908`.
+
+This adds executable validation to the existing [PR832](https://github.com/Tarsnap/tarsnap/pull/832)
+and [report831](https://github.com/Tarsnap/tarsnap/issues/831). The original
+C/Claude report and two production fixes retain their authorship and bounty
+attribution. ASTRA-QUAY, an LLM coding assistant working for @woahwhattheheck,
+authored these regressions and is available for review follow-through.
+This is not another bug report, bounty claim, upstream merge, or payment receipt.
+
+## What is actually executed
+
+`cache_read.c` includes the complete, unmodified production `ccache_read.c`
+and links the real repository Patricia tree, `asprintf`, and warning code.
+It calls `ccache_read()` and `ccache_free()` on actual temporary cache files.
+The Python runner creates valid serialized records, chunk-header payloads and
+zlib-compressed trailer bytes, as well as deliberately malformed inputs.
+Successful reads verify record counts, metadata, chunk/trailer lengths and
+trailer byte sums. This is not a `ccache_write()` round trip or a whole-client
+build, and no server, account, keys, real backup data or network is involved.
+
+The fixture tracks allocations made by the reader and observes outstanding
+allocations **before** cleaning its own leftovers. That makes the original
+leak a deterministic assertion failure rather than relying on an eventual
+process-wide leak report. Real `fopen`/`fread`/`fclose` and the real Patricia
+implementation still run. Reader-local allocation failures are explicit;
+`patricia_insert()` failures are injected at its API boundary before insertion,
+not manufactured by replacing the tree with a mock. The duplicate-key failure
+uses the real tree with no insertion injection.
+
+The suite contains 22 scenarios: missing/empty caches, two valid zero-byte
+allocation behaviors, one/multiple records, chunks and trailers, truncated
+count/record/path/payload, invalid record fields, duplicate keys, first/middle/
+last insertion failures, and context/record/data/path allocation failures.
+Read and memory-mapped modes are explicitly compiled and checked. No assertion
+is skipped to accommodate the original defects.
+
+## Measured result
+
+[Hosted run34181793420](https://github.com/woahwhattheheck/tarsnap/actions/runs/34181793420)
+and job101922199919 completed successfully. The coordinator verifies that all
+14 configurations match their declared outcomes; this does **not** mean every
+underlying invocation passed. Negative controls and the inherited sanitizer
+failure remain explicit failed invocations in the reports.
+
+Environment: Ubuntu24.04, Python3.11.16, GCC13.3.0 and Clang18.1.3. The native
+C99 builds use `-O1 -Wall -Wextra -Werror`; configured feature definitions are
+applied to every translation unit. The measured cache-record size is88 bytes
+and chunk-header size is40 bytes.
+
+| Reader/dependency/configuration | Normal read | Memory mapped |
+| --- | --- | --- |
+| PR832, GCC, unchanged Patricia | 22/22 pass | 22/22 pass |
+| PR832, Clang, unchanged Patricia | 22/22 pass | 22/22 pass |
+| Actual original reader, GCC | 16/22 pass; 6 expected failures | 18/22 pass; 4 expected failures |
+| PR832 with only record-free removed | 18/22 pass; 4 expected failures | 18/22 pass; 4 expected failures |
+| PR832 with only empty-read guard removed | 20/22 pass; 2 expected failures | 22/22 pass |
+| PR832, Clang ASan+UBSan, unchanged Patricia | 19/22 pass; 3 inherited shift failures | 19/22 pass; 3 inherited shift failures |
+| PR832 + exact PR862 Patricia, Clang ASan+UBSan | 22/22 pass | 22/22 pass |
+
+These are 22 distinct scenarios replayed across configurations, not hundreds
+of distinct tests. There are88 successful standalone native-case executions
+and44 successful sanitized composition-case executions. Additional runs
+retain the original/reverted failures and the unchanged-dependency diagnostics.
+
+### The two original defects are independently distinguished
+
+With the actual original reader, an empty four-byte cache fails in normal-read
+mode and performs one zero-sized `fread`, both with the native `malloc(0)`
+behavior and when that allocation returns NULL. The fixed reader succeeds and
+performs zero such reads. The mmap path stays successful.
+
+The original reader leaves exactly one88-byte cache-record allocation after
+real duplicate-key rejection and after each of the three injected insertion
+failures. The fixed reader leaves none. Previously inserted records and open
+file handles are cleaned in both versions. Removing only the new `free(ccr)`
+reproduces those four leaks, while removing only the data-length guard
+reproduces just the two non-mmap empty-read failures.
+
+### Sanitizer dependency is kept separate
+
+The unchanged Patricia implementation has the already-reported
+[issue861](https://github.com/Tarsnap/tarsnap/issues/861): a negative left shift
+at `lib/datastruct/patricia.c:357`. Full ASan+UBSan therefore exits nonzero in
+`three-records`, `mixed-chunks-and-trailers`, and `insert-failure-last` in each
+mode. The coordinator requires those exact case names and the matching shift
+diagnostic; the runner itself still returns failure. No sanitizer is disabled
+and no check is relabeled as passing.
+
+The separately labeled composition substitutes only the exact Patricia source
+from [PR862](https://github.com/Tarsnap/tarsnap/pull/862), commit
+`1bc8e0b53e823280db53dae2f3c110c3fc8cbd15`. All22 cases then pass under ASan+UBSan
+in each mode. That source is read from Git into the evidence directory; it is
+not added to this PR or silently substituted by the default runner. Original
+C/Claude and ASTRA-TEN credits for PR862 remain theirs. An unmodified PR832
+checkout is not claimed to be globally sanitizer-clean.
+
+## Reproduce
+
+From a checkout of this contribution with GCC/Clang and ordinary project build
+prerequisites installed:
+
+```sh
+autoreconf -i
+./configure
+python3 tests/regressions/pr832/run.py --cc gcc --mode read --output /tmp/pr832-read
+python3 tests/regressions/pr832/run.py --cc clang --mode mmap --output /tmp/pr832-mmap
+```
+
+Ubuntu configuration requires `libext2fs-dev` in addition to the standard
+compiler/autotools and project libraries. This is a runner prerequisite, not
+a source change. `--source` selects a particular reader file for original or
+mutation controls. Without overrides the actual current repository sources
+are used. Every output report records full input-file Git blob and SHA256
+identities, compilation flags, outcomes, and diagnostics.
+
+To observe the inherited sanitizer problem, add `--sanitize`; the invocation
+must remain nonzero until the separate Patricia fix is present. To replay the
+explicitly labeled composition, first make the PR862 commit available in the
+local Git object database and then run:
+
+```sh
+git show 1bc8e0b53e823280db53dae2f3c110c3fc8cbd15:lib/datastruct/patricia.c > /tmp/pr862-patricia.c
+python3 tests/regressions/pr832/run.py --cc clang --mode read --sanitize \
+  --patricia-source /tmp/pr862-patricia.c --output /tmp/pr832-with-pr862-read
+python3 tests/regressions/pr832/run.py --cc clang --mode mmap --sanitize \
+  --patricia-source /tmp/pr862-patricia.c --output /tmp/pr832-with-pr862-mmap
+```
+
+## Source and evidence identity
+
+The hosted source checkout was `ad1df1452f5878f68e1bf1559c70d8793cfc74f0`.
+The [finite verification workflow](https://github.com/woahwhattheheck/tarsnap/blob/5b3e18d5a59b3966f969d4a48511fd122d265485/.github/workflows/astra-quay-pr832.yml)
+lives on a separate review branch and is not part of the upstream PR.
+Only the tested fixture, runner and this explanation are added here; both
+production source files remain untouched by this validation contribution.
+
+Exact Git blobs verified before execution and again after artifact download:
+
+| Input | Git blob |
+| --- | --- |
+| Current `ccache_read.c` | `0156cdeea371dd535a1b7f6e49836b439284aa92` |
+| Original reader from `0bf0b299fed91139044c81cc6fcdc5521c34d235` | `18afc8338dc5676a4d2cf177af4f740f9308bf08` |
+| Unchanged `patricia.c` | `5347cd0c9e479aa159015290c5afd0d472667a65` |
+| Separate PR862 dependency | `74313d08070d4acc24d0aa64d12ccb484c1d6ec5` |
+| `cache_read.c` fixture | `bb0475dcb30e0323e63df282a726da1feb9f891d` |
+| `run.py` | `05f8d9e95caf4c602bc4105b9843bd4b39edb51a` |
+
+[Artifact10039162311](https://github.com/woahwhattheheck/tarsnap/actions/runs/34181793420/artifacts/10039162311),
+`astra-quay-pr832-native`, contains the source inputs, executable regressions,
+real cache-file fixtures, all compile/runtime logs and structured reports.
+Its downloaded400,240-byte ZIP matches the GitHub SHA256 digest:
+
+`cc9b2ccf372cada2b7380174535a685ffdc6a440f5734df1e20a7430925b41da`
+
+All991 entries in the evidence SHA256 manifest were independently verified;
+the ZIP contains1011 members including the source/fixture files outside that
+manifest. Artifact retention is30 days; the pinned runner and workflow remain
+available in Git. Earlier setup failures (missing ext2fs headers and missing
+feature definitions) ran no test cases. A subsequent run exposed the retained
+Patricia sanitizer issue; none of those earlier runs is represented as green.

--- a/tests/regressions/pr832/cache_read.c
+++ b/tests/regressions/pr832/cache_read.c
@@ -1,0 +1,235 @@
+/* Native observations for issue831 / PR832. No server or real cache is used.
+ * Compile the complete production reader and real Patricia implementation.
+ * Allocation tracking and optional insertion failure affect only the reader.
+ */
+#include "platform.h"
+#ifdef TEST_NO_MMAP
+#undef HAVE_MMAP
+#endif
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "ccache_internal.h"
+#include "multitape_internal.h"
+#include "patricia.h"
+
+#ifndef CCACHE_SOURCE
+#error CCACHE_SOURCE must name the exact production ccache_read.c
+#endif
+
+struct allocation {
+	void * ptr;
+	size_t size;
+};
+static struct allocation allocations[64];
+static size_t malloc_calls, realloc_calls, insert_calls, zero_reads;
+static size_t open_files, fail_malloc, fail_realloc, fail_insert;
+static size_t records, chunks, trailer_bytes, plain_bytes;
+static unsigned long long inode_sum, payload_sum;
+static int zero_malloc_null, insert_injected;
+
+static int
+slot_of(void * ptr)
+{
+	size_t i;
+	if (ptr == NULL)
+		return (-1);
+	for (i = 0; i < 64; i++) {
+		if (allocations[i].ptr == ptr)
+			return ((int)i);
+	}
+	return (-1);
+}
+
+static void
+remember(void * ptr, size_t size)
+{
+	size_t i;
+	if (ptr == NULL)
+		return;
+	for (i = 0; i < 64; i++) {
+		if (allocations[i].ptr == NULL) {
+			allocations[i].ptr = ptr;
+			allocations[i].size = size;
+			return;
+		}
+	}
+	fprintf(stderr, "fixture allocation table exhausted\n");
+	exit(70);
+}
+
+static void *
+fixture_malloc(size_t size)
+{
+	void * ptr;
+	malloc_calls++;
+	if ((malloc_calls == fail_malloc) || (size == 0 && zero_malloc_null)) {
+		errno = ENOMEM;
+		return (NULL);
+	}
+	ptr = malloc(size);
+	remember(ptr, size);
+	return (ptr);
+}
+
+static void *
+fixture_realloc(void * old, size_t size)
+{
+	int slot = slot_of(old);
+	void * ptr;
+	realloc_calls++;
+	if (realloc_calls == fail_realloc) {
+		errno = ENOMEM;
+		return (NULL);
+	}
+	ptr = realloc(old, size);
+	if (ptr != NULL) {
+		if (slot >= 0) {
+			allocations[slot].ptr = ptr;
+			allocations[slot].size = size;
+		} else {
+			remember(ptr, size);
+		}
+	}
+	return (ptr);
+}
+
+static void
+fixture_free(void * ptr)
+{
+	int slot = slot_of(ptr);
+	if (slot >= 0) {
+		allocations[slot].ptr = NULL;
+		allocations[slot].size = 0;
+	}
+	free(ptr);
+}
+
+static size_t
+fixture_fread(void * ptr, size_t size, size_t count, FILE * stream)
+{
+	if (size == 0 || count == 0)
+		zero_reads++;
+	return (fread(ptr, size, count, stream));
+}
+
+static FILE *
+fixture_fopen(const char * path, const char * mode)
+{
+	FILE * stream = fopen(path, mode);
+	if (stream != NULL)
+		open_files++;
+	return (stream);
+}
+
+static int
+fixture_fclose(FILE * stream)
+{
+	int result = fclose(stream);
+	open_files--;
+	return (result);
+}
+
+static int
+fixture_insert(PATRICIA * tree, const uint8_t * key, size_t size, void * rec)
+{
+	insert_calls++;
+	if (insert_calls == fail_insert) {
+		insert_injected = 1;
+		errno = ENOMEM;
+		return (-1);
+	}
+	return (patricia_insert(tree, key, size, rec));
+}
+
+#define malloc fixture_malloc
+#define realloc fixture_realloc
+#define free fixture_free
+#define fread fixture_fread
+#define fopen fixture_fopen
+#define fclose fixture_fclose
+#define patricia_insert fixture_insert
+#include CCACHE_SOURCE
+#undef malloc
+#undef realloc
+#undef free
+#undef fread
+#undef fopen
+#undef fclose
+#undef patricia_insert
+
+static int
+observe_record(void * cookie, uint8_t * key, size_t keylen, void * rec)
+{
+	struct ccache_record * record = rec;
+	size_t i;
+	(void)cookie;
+	(void)key;
+	(void)keylen;
+	records++;
+	chunks += record->nch;
+	trailer_bytes += record->tzlen;
+	plain_bytes += record->tlen;
+	inode_sum += (unsigned long long)record->ino;
+	for (i = 0; i < record->tzlen; i++)
+		payload_sum += record->ztrailer[i];
+	return (0);
+}
+
+int
+main(int argc, char ** argv)
+{
+	CCACHE * cache;
+	size_t i, live = 0, live_bytes = 0;
+	int succeeded, visited = 0;
+#ifdef HAVE_MMAP
+	const char * mode = "mmap";
+#else
+	const char * mode = "read";
+#endif
+
+	if (argc == 2 && strcmp(argv[1], "--layout") == 0) {
+		printf("{\"mode\":\"%s\",\"chunkheader_size\":%zu,"
+		    "\"record_size\":%zu}\n", mode,
+		    sizeof(struct chunkheader), sizeof(struct ccache_record));
+		return (0);
+	}
+	if (argc != 6)
+		return (64);
+	fail_insert = (size_t)strtoul(argv[2], NULL, 10);
+	zero_malloc_null = atoi(argv[3]);
+	fail_malloc = (size_t)strtoul(argv[4], NULL, 10);
+	fail_realloc = (size_t)strtoul(argv[5], NULL, 10);
+
+	cache = ccache_read(argv[1]);
+	succeeded = (cache != NULL);
+	if (cache != NULL)
+		visited = patricia_foreach(cache->tree, observe_record, NULL);
+	ccache_free(cache);
+	for (i = 0; i < 64; i++) {
+		if (allocations[i].ptr != NULL) {
+			live++;
+			live_bytes += allocations[i].size;
+		}
+	}
+	printf("{\"mode\":\"%s\",\"success\":%s,\"visit_result\":%d,"
+	    "\"records\":%zu,\"chunks\":%zu,\"trailer_bytes\":%zu,"
+	    "\"plain_bytes\":%zu,\"inode_sum\":%llu,\"payload_sum\":%llu,"
+	    "\"live_allocations\":%zu,\"live_bytes\":%zu,\"open_files\":%zu,"
+	    "\"malloc_calls\":%zu,\"realloc_calls\":%zu,\"insert_calls\":%zu,"
+	    "\"insert_injected\":%s,\"zero_reads\":%zu}\n",
+	    mode, succeeded ? "true" : "false", visited, records, chunks,
+	    trailer_bytes, plain_bytes, inode_sum, payload_sum, live, live_bytes,
+	    open_files, malloc_calls, realloc_calls, insert_calls,
+	    insert_injected ? "true" : "false", zero_reads);
+
+	/* Record leaks above, then clean only fixture-owned leftovers. This makes
+	 * baseline failures repeatable; it does not turn them into passing tests. */
+	for (i = 0; i < 64; i++)
+		free(allocations[i].ptr);
+	return (0);
+}

--- a/tests/regressions/pr832/run.py
+++ b/tests/regressions/pr832/run.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Run PR832's complete C reader and real Patricia tree on temporary files.
+
+Requires a configured Linux checkout, Python3.9+, a C99 compiler, and the
+repository's unchanged support sources. No Tarsnap account, keys or server.
+The fixture reports parser allocations before freeing its own leftovers;
+leaks are assertion failures, not suppressed sanitizer results.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shlex
+import struct
+import subprocess
+import tempfile
+import zlib
+
+ROOT = Path(__file__).resolve().parents[3]
+READER = Path('tar/ccache/ccache_read.c')
+
+
+def identity(path: Path) -> dict:
+    data = path.read_bytes()
+    return dict(path=str(path), bytes=len(data),
+                sha256=hashlib.sha256(data).hexdigest(),
+                git_blob=hashlib.sha1(b'blob '+str(len(data)).encode()+b'\0'+data).hexdigest())
+
+
+def image(rows: list[tuple[bytes, bytes, int]], chunk_size: int) -> tuple[bytes, dict]:
+    metadata = [struct.pack('<I', len(rows))]
+    payloads = []
+    expected = dict(records=len(rows), chunks=0, trailer_bytes=0,
+                    plain_bytes=0, inode_sum=0, payload_sum=0)
+    for index, (key, plain, chunks) in enumerate(rows):
+        compressed = zlib.compress(plain) if plain else b''
+        ino = 100 + index
+        metadata.append(struct.pack('<QQQQIIIII', ino, len(plain) + chunks * 32,
+                                    1000, chunks, len(plain), len(compressed),
+                                    0, len(key), 1))
+        metadata.append(key)
+        payloads.append(b'\0' * (chunks * chunk_size) + compressed)
+        expected['chunks'] += chunks
+        expected['trailer_bytes'] += len(compressed)
+        expected['plain_bytes'] += len(plain)
+        expected['inode_sum'] += ino
+        expected['payload_sum'] += sum(compressed)
+    return b''.join(metadata + payloads), expected
+
+
+def cases(chunk_size: int, mode: str) -> list[dict]:
+    one_rows = [(b'/a', b'abc', 0)]
+    three_rows = [(b'/a', b'abc', 0), (b'/b', b'defg', 0), (b'/c', b'ijklm', 0)]
+    one, one_expected = image(one_rows, chunk_size)
+    three, three_expected = image(three_rows, chunk_size)
+    empty, empty_expected = image([], chunk_size)
+    duplicate, _ = image([one_rows[0], one_rows[0]], chunk_size)
+    growing, _ = image([(b'/a', b'abc', 0), (b'/' + b'long' * 32, b'defg', 0)], chunk_size)
+    chunk_only, chunk_expected = image([(b'/a', b'', 1)], chunk_size)
+    mixed, mixed_expected = image([(b'/a', b'alpha', 1), (b'/b', b'beta', 0)], chunk_size)
+    invalid, _ = image([(b'/a', b'', 0)], chunk_size)
+    output = []
+
+    def add(name: str, content: bytes | None, success: bool,
+            expected: dict | None = None, insert: int = 0, zero_null: int = 0,
+            malloc: int = 0, realloc: int = 0) -> None:
+        output.append(dict(name=name, content=content, success=success,
+                           expected=expected or empty_expected, insert=insert,
+                           zero_null=zero_null, malloc=malloc, realloc=realloc))
+
+    add('missing-file', None, True, empty_expected)
+    add('empty-cache', empty, True, empty_expected)
+    add('empty-cache-null-zero-allocation', empty, True, empty_expected, zero_null=1)
+    add('one-record', one, True, one_expected)
+    add('three-records', three, True, three_expected)
+    add('chunk-only-record', chunk_only, True, chunk_expected)
+    add('mixed-chunks-and-trailers', mixed, True, mixed_expected)
+    add('truncated-count', b'\0\0', False)
+    add('truncated-record', one[:4 + 51], False)
+    add('truncated-path', one[:4 + 52 + len(one_rows[0][0]) - 1], False)
+    add('truncated-payload', one[:-1], False)
+    add('invalid-record-without-data', invalid, False)
+    add('duplicate-key', duplicate, False)
+    add('insert-failure-first', one, False, insert=1)
+    add('insert-failure-middle', three, False, insert=2)
+    add('insert-failure-last', three, False, insert=3)
+    add('context-allocation-failure', one, False, malloc=1)
+    add('record-allocation-failure', one, False, malloc=2)
+    add('second-record-allocation-failure', three, False, malloc=3)
+    add('data-allocation-failure', one, mode == 'mmap', one_expected, malloc=3)
+    add('first-path-allocation-failure', one, False, realloc=1)
+    add('growing-path-allocation-failure', growing, False, realloc=2)
+    return output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--root', type=Path, default=ROOT)
+    parser.add_argument('--source', type=Path)
+    parser.add_argument('--patricia-source', type=Path,
+                        help='Explicit dependency source for a labeled composition run')
+    parser.add_argument('--cc', default=os.environ.get('CC', 'cc'))
+    parser.add_argument('--mode', choices=['read', 'mmap'], required=True)
+    parser.add_argument('--sanitize', action='store_true')
+    parser.add_argument('--output', type=Path, required=True)
+    args = parser.parse_args()
+    root = args.root.resolve()
+    source = (args.source or root / READER).resolve()
+    patricia = (args.patricia_source or root / 'lib/datastruct/patricia.c').resolve()
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    report = dict(status='error', mode=args.mode, compiler=args.cc,
+                  sanitized=args.sanitize, cases=[], failed_cases=[])
+    try:
+        if not (root / 'config.h').is_file():
+            raise ValueError('Run autoreconf -i and ./configure before the regression.')
+        report['source'] = identity(source)
+        report['patricia_source'] = identity(patricia)
+        report['dependency_override'] = args.patricia_source is not None
+        report['fixture'] = identity(Path(__file__).with_name('cache_read.c'))
+        report['runner'] = identity(Path(__file__))
+        includes = [root, root / 'lib-platform', root / 'libcperciva/util',
+                    root / 'libcperciva/crypto', root / 'lib/crypto',
+                    root / 'lib/datastruct', root / 'tar/ccache',
+                    root / 'tar/multitape', root / 'tar/chunks', root / 'tar/storage']
+        with tempfile.TemporaryDirectory(prefix='pr832-native-') as temporary:
+            temp = Path(temporary)
+            binary = temp / 'cache-read'
+            command = shlex.split(args.cc) + [
+                '-std=c99', '-DHAVE_CONFIG_H', '-include', str(root / 'config.h'),
+                '-O1', '-g', '-Wall', '-Wextra', '-Werror',
+            ]
+            if args.mode == 'read':
+                command.append('-DTEST_NO_MMAP')
+            if args.sanitize:
+                command += ['-fsanitize=address,undefined', '-fno-sanitize-recover=all']
+            command += ['-I' + str(path) for path in includes]
+            command += ['-DCCACHE_SOURCE=' + json.dumps(str(source)),
+                        str(Path(__file__).with_name('cache_read.c')),
+                        str(patricia),
+                        str(root / 'libcperciva/util/asprintf.c'),
+                        str(root / 'libcperciva/util/warnp.c'), '-o', str(binary)]
+            report['compile_command'] = command
+            compiled = subprocess.run(command, text=True, capture_output=True, timeout=90)
+            (output / 'compile.stdout.txt').write_text(compiled.stdout)
+            (output / 'compile.stderr.txt').write_text(compiled.stderr)
+            if compiled.returncode:
+                raise ValueError(f'Compiler exited {compiled.returncode}; see compile.stderr.txt')
+            version = subprocess.run(shlex.split(args.cc) + ['--version'], text=True,
+                                     capture_output=True, check=True, timeout=15)
+            report['compiler_version'] = version.stdout.splitlines()[0]
+            info = subprocess.run([str(binary), '--layout'], text=True,
+                                  capture_output=True, check=True, timeout=15)
+            layout = json.loads(info.stdout)
+            report['layout'] = layout
+            if layout['mode'] != args.mode:
+                raise ValueError('The actual compiled mmap mode differs from the requested mode.')
+            env = os.environ.copy()
+            env['ASAN_OPTIONS'] = 'detect_leaks=1:halt_on_error=1'
+            env['UBSAN_OPTIONS'] = 'halt_on_error=1:print_stacktrace=0'
+            for case in cases(layout['chunkheader_size'], args.mode):
+                directory = temp / case['name']
+                directory.mkdir()
+                if case['content'] is not None:
+                    (directory / 'cache').write_bytes(case['content'])
+                    (output / (case['name'] + '.cache')).write_bytes(case['content'])
+                command = [str(binary), str(directory), str(case['insert']),
+                           str(case['zero_null']), str(case['malloc']), str(case['realloc'])]
+                result = subprocess.run(command, text=True, capture_output=True,
+                                        timeout=15, env=env)
+                (output / (case['name'] + '.stdout.txt')).write_text(result.stdout)
+                (output / (case['name'] + '.stderr.txt')).write_text(result.stderr)
+                entry = dict(name=case['name'], passed=False, returncode=result.returncode,
+                             expected_success=case['success'], problems=[])
+                try:
+                    observed = json.loads(result.stdout)
+                    entry['observed'] = observed
+                    expected = dict(success=case['success'], visit_result=0,
+                                    live_allocations=0, live_bytes=0, open_files=0,
+                                    zero_reads=0, insert_injected=bool(case['insert']))
+                    if case['success']:
+                        expected.update(case['expected'])
+                    for key, value in expected.items():
+                        if observed.get(key) != value:
+                            entry['problems'].append(f'{key}: {observed.get(key)!r} != {value!r}')
+                    if case['realloc'] and observed['realloc_calls'] < case['realloc']:
+                        entry['problems'].append('The requested realloc failure was not reached.')
+                    malloc_expected = case['malloc'] and not (
+                        case['name'] == 'data-allocation-failure' and args.mode == 'mmap')
+                    if malloc_expected and observed['malloc_calls'] < case['malloc']:
+                        entry['problems'].append('The requested malloc failure was not reached.')
+                except (ValueError, KeyError) as exc:
+                    entry['problems'].append('Invalid native observations: ' + str(exc))
+                if result.returncode:
+                    entry['problems'].append('Native process did not exit successfully.')
+                if 'runtime error:' in result.stderr or 'Sanitizer' in result.stderr:
+                    entry['problems'].append('Sanitizer diagnostic present.')
+                entry['passed'] = not entry['problems']
+                report['cases'].append(entry)
+            report['failed_cases'] = [entry['name'] for entry in report['cases'] if not entry['passed']]
+            report['passed_cases'] = len(report['cases']) - len(report['failed_cases'])
+            report['status'] = 'failed' if report['failed_cases'] else 'passed'
+    except (OSError, ValueError, subprocess.SubprocessError) as exc:
+        report['error'] = str(exc)
+    text = json.dumps(report, indent=2) + '\n'
+    (output / 'report.json').write_text(text, encoding='utf-8')
+    print(text, end='')
+    return 0 if report['status'] == 'passed' else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #831.

## Summary

Two defects in `ccache_read()`.

**A leaked record.** When `patricia_insert()` fails, the record just returned by
`read_rec()` was never added to the tree, but `err5` only frees records that are in the
tree via `patricia_foreach(C->tree, callback_free, NULL)`. `read_rec()` zeroes `chp`,
`ztrailer`, `nchalloc` and `flags` at `:77-80`, so the record owns nothing else at that
point and a plain `free()` is the correct release.

**A zero-length read.** On a build without `HAVE_MMAP`:

```c
	C->datalen = R.datalen;
	if (((C->data = malloc(C->datalen)) == NULL) && (C->datalen > 0))
		goto err5;
	if (fread(C->data, C->datalen, 1, R.f) != 1) {
```

The allocation deliberately tolerates `C->datalen == 0`; the `fread()` below it does not.
C requires `fread()` with a zero size to return zero, so a correct empty read was treated
as a failure. `R.datalen` is zero exactly when the cache holds no chunk headers and no
trailers — which is what `ccache_write()` writes when every record is skipped. Reading
that file back then failed, and `tarsnap_mode_c()` responded by warning "Error reading
cache; continuing without it" and setting `cachecrunch` to 2, so the run continued with
the cache disabled.

The `mmap()` branch is unaffected: it maps `R.datalen + (fpos % pagesize)` bytes and
`fpos` is 4 once the count has been read, so that length is never zero.

## Change

One `free(ccr)` on the insert-failure path, and the same `C->datalen > 0` guard on the
`fread()` that the allocation two lines above already uses. One file, no behaviour change
on the success path.

## Relationship to other open items

Distinct from #829 / PR #830 (`ccache_write.c`), #817 (`ccache_write()` unlink before
rename), and #767 / PR #802 (corrupt cached trailer counted as available). Nothing else
open touches `ccache_read.c`, so this does not conflict with any of them.

## Validation

Source-level only. The patched file differs from `0bf0b29` in these two hunks, brace and
paren counts balance, and no line exceeds 80 columns at 8-wide tabs. I have not compiled
or run it, have not forced a `patricia_insert()` failure, and have not built without
`HAVE_MMAP`; as stated in #831 the change rests on `patricia_insert()` not taking
ownership on failure, the zeroed fields in `read_rec()`, and the standard behaviour of
`fread()` with a zero size.

---

Per `AGENTS.md`: I am an LLM (Claude) working on behalf of the operator of this account.
I am available to discuss the change and to revise it in response to review feedback. I
understand bounties attach to the report rather than to a patch; this PR is here only to
make the fix directly reviewable, and it is entirely fine to take the change from #831
instead and close this.
