### PR TITLE
multitape: free the parsed metadata when the name check fails

### DIFF
--- a/tar/multitape/multitape_metadata.c
+++ b/tar/multitape/multitape_metadata.c
@@ -347,10 +347,14 @@ multitape_metadata_get(STORAGE_R * S, CHUNKS_S * C,
 	 * name of the metadata file.
 	 */
 	if (crypto_hash_data(CRYPTO_KEY_HMAC_NAME,
-	    (uint8_t *)mdat->name, strlen(mdat->name), hbuf))
+	    (uint8_t *)mdat->name, strlen(mdat->name), hbuf)) {
+		multitape_metadata_free(mdat);
 		goto err0;
-	if (crypto_verify_bytes(tapehash, hbuf, 32))
+	}
+	if (crypto_verify_bytes(tapehash, hbuf, 32)) {
+		multitape_metadata_free(mdat);
 		goto corrupt;
+	}
 
 	/* Success! */
 	return (0);

--- a/tests/regressions/pr838/HOSTED.md
+++ b/tests/regressions/pr838/HOSTED.md
@@ -1,0 +1,60 @@
+# Hosted PR838 validation receipt
+
+Executed 2026-09-08 UTC. This advances existing Tarsnap/tarsnap#838 and report #837;
+C/Claude retains discovery and implementation credit. ASTRA-RELAY-COOLDOWN
+(ChatGPT, an LLM working for the account operator) supplied this validation.
+
+Run: https://github.com/woahwhattheheck/tarsnap/actions/runs/34179206496
+Job: https://github.com/woahwhattheheck/tarsnap/actions/runs/34179206496/job/101914645696
+The job completed SUCCESS, including exact-source checks, all regression/control
+commands, native build, five offline version checks, and artifact upload.
+
+The support workflow is on `ci/astra-pr838-cleanup-20260908` at
+`6345fcb3bae0573b9c76e3dbe4513cd7a8f1fae9`; it checks out the contribution's exact
+`d6d6aeb2e4c9db931b5148e7fa3e429176c39cf4`. It is not part of the upstream PR.
+
+## Results read from the downloaded artifact
+
+| Configuration | Passed | Failed |
+| --- | ---: | ---: |
+| Fixed source, GCC 11.4 | 94 | 0 |
+| Fixed source, Clang 14 | 94 | 0 |
+| Fixed source, Clang 14 ASan + UBSan | 94 | 0 |
+| Exact pre-fix source, GCC | 66 | 28 |
+| Only hash-error cleanup removed, GCC | 82 | 12 |
+| Only mismatch cleanup removed, GCC | 78 | 16 |
+
+Every negative-control failure returned exit 1 and retained allocations. Their
+failing scenario sets were checked independently. The 94 cases are the same
+matrix across compilers, not 282 distinct tests. All five compiled binaries
+returned `1.0.41-head` for `--version`.
+
+Exact tested blobs:
+- Production, unchanged: `487d27fbc9915f6d4c35f2a2e503395b730e988a`.
+- `cleanup.c`: `a26da8767627f66975e3440cb74d20742c00c59c`.
+- `run.py`: `d64c348c4542f9b80ad4382daf0fef184838e8af`.
+- Pre-fix production: `f715b9dba159edf2be71d517a79d54e29781ebc2`.
+
+Artifact `astra-pr838-validated-34179206496`, ID `10038303224`, 42,453 bytes.
+ZIP SHA-256: `9c01e1db14dd73a9799b9ec83e73ea44251224cafda13667c5f31a027db2ecf0`.
+The downloaded ZIP matches GitHub's digest; all 26 payload entries match the
+included SHA256SUMS. The tested C/Python files also match the locally executed
+and published files byte-for-byte. Artifact expiry reported by GitHub:
+2026-09-22T02:12:33Z. Source and replay remain committed after artifact expiry.
+
+The earlier source-capture run 34178725998 failed during configuration because
+its disposable runner lacked ext2fs headers. This successful follow-up installed
+the normal build dependency. No production fix was changed to make it pass.
+
+## Boundaries and publication
+
+See README.md for the exact fixture and replay. Real metadata parsing/get/free
+and byte comparison execute; storage, hash outputs and RSA verification are
+synthetic. This does not validate cryptography, exercise live servers, execute a
+full `make test`, certify upstream-required CI, or prove exploitability.
+
+One evidence-comment attempt to upstream PR838 returned HTTP 403, `Resource not
+accessible by integration`; no upstream comment was posted. This receipt is
+therefore committed to the existing contribution branch, which already backs the
+upstream PR. No duplicate issue/PR, repeated sponsor send, new bounty claim,
+maintainer acceptance, merge, award or payment is represented here.

--- a/tests/regressions/pr838/README.md
+++ b/tests/regressions/pr838/README.md
@@ -1,0 +1,88 @@
+# PR838 metadata cleanup regression
+
+This is additive validation of the existing fix in Tarsnap/tarsnap#838 and report
+#837. C/Claude retains the original discovery and implementation credit.
+ASTRA-RELAY-COOLDOWN (ChatGPT, an LLM working for this account's operator) added
+these tests. This is not a new bounty report or a claim of acceptance/payment.
+Review follow-through remains in the existing PR and operator coordination thread;
+this report does not promise unattended monitoring.
+
+## What runs
+
+`cleanup.c` includes the **complete, unmodified** production metadata translation
+unit and authentic project headers. It links the actual `crypto_verify_bytes.c`.
+The parser, get-by-name/get-by-hash entrypoints, and metadata-free implementation
+therefore execute as production C, rather than a reimplementation or extracted
+function. Link-time section collection drops unrelated entrypoints.
+
+Storage, RSA verification, the name-hash operation, and allocation failures use
+local synthetic fixtures. The storage fixture hands the real parser an encoded
+metadata buffer. Successful RSA verification is simulated; this is neither a
+cryptographic test nor a live server/tampering demonstration. No real keys,
+account, server, network call or filesystem archive is used by the focused test.
+
+Allocation wrappers perform actual allocations and releases while counting live
+pointers/bytes and invalid frees. Failure is recorded before fixture leftovers
+are cleaned. A baseline leak cannot become a pass because the fixture cleans up.
+
+The 94 cases cover both entrypoints, quiet/nonquiet diagnostics, zero/one/three
+arguments, both post-decode exits, 100 repeated mismatch requests, successful
+caller ownership, missing/corrupt/error reads, initial name-hash failure, malformed
+metadata, signature outcomes, and every allocation-failure point for three args.
+No assertions require cleared pointers: the production free function does not
+promise to zero the structure.
+
+## Executed results
+
+Original PR source commit: `bebf285f6c36f266e64edad064260411f3936b44`.
+Unchanged fixed source blob: `487d27fbc9915f6d4c35f2a2e503395b730e988a`.
+Pre-fix source blob at base `0bf0b299fed91139044c81cc6fcdc5521c34d235`:
+`f715b9dba159edf2be71d517a79d54e29781ebc2`.
+
+In isolated Linux execution on 2026-09-08 UTC:
+
+| Source / toolchain | Passing cases | Failing cases |
+| --- | ---: | ---: |
+| Existing fix, GCC 14.2 | 94 | 0 |
+| Existing fix, Clang 17 | 94 | 0 |
+| Existing fix, Clang 17 ASan + UBSan | 94 | 0 |
+| Exact pre-fix source, GCC | 66 | 28 |
+| Remove only post-decode hash-error cleanup, GCC | 82 | 12 |
+| Remove only name-mismatch cleanup, GCC | 78 | 16 |
+
+The pre-fix failures retain 2/3/5 allocations (8/24/50 requested bytes in these
+fixtures) for zero/one/three args. Return codes remain the expected -1 or 2;
+checking only the return code would miss the defect. Each independent removal
+fails exactly its targeted cleanup scenarios, while the other scenarios pass.
+
+A fresh `autoreconf -i`, `./configure`, `make -j2`, and `--version` on all five
+binaries also passed locally for this PR's source. This is one native build, not
+server integration or a full `make test` result. The first hosted capture run
+34178725998 stopped during configure because its image lacked ext2fs headers;
+that failed build is not a source-test result or a hosted pass. Hosted follow-up
+results, when available, are recorded in the existing PR/coordination thread.
+
+## Replay
+
+Use a configured Linux checkout, Python 3.9+, GCC or Clang, and a GNU-compatible
+linker. Install the project's normal build dependencies first. On Ubuntu these
+include the ext2fs development headers (`e2fslibs-dev`). No Python packages needed.
+
+```sh
+autoreconf -i
+./configure
+python3 tests/regressions/pr838/run.py --output /tmp/pr838-fixed.json
+python3 tests/regressions/pr838/run.py --cc clang --sanitize --output /tmp/pr838-asan.json
+# The same tests must fail against the original source. Do not edit the checkout.
+git show 0bf0b299fed91139044c81cc6fcdc5521c34d235:tar/multitape/multitape_metadata.c > /tmp/pr838-baseline.c
+python3 tests/regressions/pr838/run.py --source /tmp/pr838-baseline.c --output /tmp/pr838-baseline.json
+```
+
+The last command intentionally exits 1 with 28 failed cases. Compile/configuration
+failure exits 2, and successful candidate execution exits 0. Independent controls
+can remove either one of the two added `multitape_metadata_free(mdat)` calls in a
+temporary source copy and pass that copy to `--source`; retain the other call.
+
+These files do not change the existing production fix, maintainer workflow,
+original report, sponsor contact, or bounty terms. The optional support workflow
+is kept on a separate owner-fork CI branch, not this contribution branch.

--- a/tests/regressions/pr838/cleanup.c
+++ b/tests/regressions/pr838/cleanup.c
@@ -1,0 +1,254 @@
+/* PR838 regression: compile the real metadata parser/get/free implementation.
+ * Storage, signing, hash failures, and allocation failure are local fixtures.
+ * This does not contact a server or test cryptographic verification.
+ */
+#include "platform.h"
+#include <sys/types.h>
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void * tracked_malloc(size_t);
+static char * tracked_strdup(const char *);
+static void tracked_free(void *);
+#define malloc tracked_malloc
+#define strdup tracked_strdup
+#define free tracked_free
+#ifndef METADATA_SOURCE
+#define METADATA_SOURCE "../../../tar/multitape/multitape_metadata.c"
+#endif
+#include METADATA_SOURCE
+#undef malloc
+#undef strdup
+#undef free
+
+struct allocation { void * pointer; size_t length; };
+static struct allocation allocations[64];
+static size_t live_count, live_bytes, invalid_frees, allocation_calls;
+static size_t fail_allocation;
+static int read_status, signature_status, hash_calls, fail_hash_call;
+static int name_mismatch, by_name, read_calls, signature_calls, warning_calls;
+static int stats_calls;
+static size_t stats_bytes;
+static uint8_t fixture[4096];
+static size_t fixture_length;
+static const char * arguments[] = { "tarsnap", "-c", "folder" };
+
+static void *
+tracked_malloc(size_t size)
+{
+	void * pointer;
+	size_t i;
+	allocation_calls++;
+	if (allocation_calls == fail_allocation) {
+		errno = ENOMEM;
+		return (NULL);
+	}
+	if ((pointer = malloc(size ? size : 1)) == NULL)
+		abort();
+	for (i = 0; i < 64; i++) {
+		if (allocations[i].pointer == NULL) {
+			allocations[i].pointer = pointer;
+			allocations[i].length = size;
+			live_count++;
+			live_bytes += size;
+			return (pointer);
+		}
+	}
+	abort();
+}
+
+static char *
+tracked_strdup(const char * text)
+{
+	size_t length = strlen(text) + 1;
+	char * pointer = tracked_malloc(length);
+	if (pointer != NULL)
+		memcpy(pointer, text, length);
+	return (pointer);
+}
+
+static void
+tracked_free(void * pointer)
+{
+	size_t i;
+	if (pointer == NULL)
+		return;
+	for (i = 0; i < 64; i++) {
+		if (allocations[i].pointer == pointer) {
+			live_bytes -= allocations[i].length;
+			live_count--;
+			allocations[i].pointer = NULL;
+			free(pointer);
+			return;
+		}
+	}
+	invalid_frees++;
+}
+
+int
+storage_read_file_alloc(STORAGE_R * storage, uint8_t ** data, size_t * length,
+    char class, const uint8_t hash[32])
+{
+	(void)storage;
+	(void)hash;
+	if (class != 'm')
+		abort();
+	read_calls++;
+	if (read_status != 0)
+		return (read_status);
+	if ((*data = tracked_malloc(fixture_length)) == NULL)
+		return (-1);
+	memcpy(*data, fixture, fixture_length);
+	*length = fixture_length;
+	return (0);
+}
+
+int
+crypto_hash_data(int key, const uint8_t * data, size_t length, uint8_t hash[32])
+{
+	if (key != CRYPTO_KEY_HMAC_NAME || length != strlen("archive") ||
+	    memcmp(data, "archive", length) != 0)
+		abort();
+	hash_calls++;
+	if (hash_calls == fail_hash_call)
+		return (-1);
+	memset(hash, name_mismatch && hash_calls == (by_name ? 2 : 1) ? 0xa5 : 0x5a, 32);
+	return (0);
+}
+
+int
+crypto_rsa_verify(int key, const uint8_t * data, size_t length,
+    const uint8_t * signature, size_t signature_length)
+{
+	(void)data;
+	(void)length;
+	(void)signature;
+	if (key != CRYPTO_KEY_SIGN_PUB || signature_length != 256)
+		abort();
+	signature_calls++;
+	return (signature_status);
+}
+
+void
+chunks_stats_extrastats(CHUNKS_S * chunks, size_t length)
+{
+	(void)chunks;
+	stats_calls++;
+	stats_bytes += length;
+}
+
+void
+libcperciva_warn(const char * format, ...)
+{
+	(void)format;
+	warning_calls++;
+}
+
+void
+libcperciva_warnx(const char * format, ...)
+{
+	(void)format;
+	warning_calls++;
+}
+
+static void
+make_fixture(int argc)
+{
+	uint8_t * p = fixture;
+	int i;
+	memcpy(p, "archive", 8); p += 8;
+	le64enc(p, 1700000000); p += 8;
+	le32enc(p, (uint32_t)argc); p += 4;
+	for (i = 0; i < argc; i++) {
+		memcpy(p, arguments[i], strlen(arguments[i]) + 1);
+		p += strlen(arguments[i]) + 1;
+	}
+	memset(p, 0x3c, 32); p += 32;
+	le64enc(p, 12345); p += 8;
+	memset(p, 0x6d, 256); p += 256;
+	fixture_length = (size_t)(p - fixture);
+}
+
+int
+main(int argc, char ** argv)
+{
+	struct tapemetadata metadata;
+	uint8_t requested[32];
+	const char * scenario;
+	int count, quiet, expected = 0, actual = 0, passed = 1, repetitions = 1, i;
+	size_t leaked_count, leaked_bytes;
+	if (argc != 5)
+		return (2);
+	scenario = argv[1]; count = atoi(argv[2]); quiet = atoi(argv[3]); by_name = atoi(argv[4]);
+	if ((count != 0 && count != 1 && count != 3) || quiet < 0 || quiet > 1 || by_name < 0 || by_name > 1)
+		return (2);
+	make_fixture(count);
+	memset(requested, 0x5a, 32);
+	if (strcmp(scenario, "mismatch") == 0 || strcmp(scenario, "repeat-mismatch") == 0) {
+		name_mismatch = 1; expected = 2;
+		if (strcmp(scenario, "repeat-mismatch") == 0)
+			repetitions = 100;
+	} else if (strcmp(scenario, "hash-error") == 0) {
+		fail_hash_call = by_name ? 2 : 1; expected = -1;
+	} else if (strcmp(scenario, "initial-hash-error") == 0) {
+		if (!by_name) return (2);
+		fail_hash_call = 1; expected = -1;
+	} else if (strcmp(scenario, "missing") == 0) {
+		read_status = 1; expected = 1;
+	} else if (strcmp(scenario, "read-corrupt") == 0) {
+		read_status = 2; expected = 2;
+	} else if (strcmp(scenario, "read-error") == 0) {
+		read_status = -1; expected = -1;
+	} else if (strcmp(scenario, "bad-signature") == 0) {
+		signature_status = 1; expected = 2;
+	} else if (strcmp(scenario, "signature-error") == 0) {
+		signature_status = -1; expected = -1;
+	} else if (strcmp(scenario, "short-signature") == 0) {
+		fixture_length--; expected = 2;
+	} else if (strcmp(scenario, "unterminated-name") == 0) {
+		memset(fixture, 'x', fixture_length); expected = 2;
+	} else if (strcmp(scenario, "truncated-argv") == 0) {
+		fixture_length = 24; memset(fixture + 20, 'x', 4); expected = 2;
+	} else if (strcmp(scenario, "negative-argc") == 0) {
+		le32enc(fixture + 16, UINT32_MAX); expected = 2;
+	} else if (strcmp(scenario, "trailing-byte") == 0) {
+		fixture[fixture_length++] = 1; expected = 2;
+	} else if (strncmp(scenario, "allocation-", 11) == 0) {
+		fail_allocation = (size_t)atoi(scenario + 11); expected = -1;
+		if (fail_allocation < 1 || fail_allocation > (size_t)count + 3) return (2);
+	} else if (strcmp(scenario, "success") != 0) {
+		return (2);
+	}
+	for (i = 0; i < repetitions; i++) {
+		memset(&metadata, 0xa5, sizeof(metadata));
+		hash_calls = 0;
+		actual = by_name ? multitape_metadata_get_byname(NULL, (CHUNKS_S *)&stats_calls,
+		    &metadata, "archive", quiet) : multitape_metadata_get_byhash(NULL,
+		    (CHUNKS_S *)&stats_calls, &metadata, requested, quiet);
+		if (actual != expected) passed = 0;
+		if (actual == 0) {
+			/* Success transfers the allocation ownership to the caller. */
+			if (live_count != (size_t)count + 2) passed = 0;
+			else if (strcmp(metadata.name, "archive") != 0 || metadata.argc != count ||
+			    metadata.indexlen != 12345 || metadata.metadatalen != fixture_length)
+				passed = 0;
+			multitape_metadata_free(&metadata);
+		}
+		if (live_count || invalid_frees) { passed = 0; break; }
+	}
+	if ((name_mismatch || strcmp(scenario, "hash-error") == 0 || expected == 0) && signature_calls != repetitions)
+		passed = 0;
+	if (strcmp(scenario, "initial-hash-error") == 0 && read_calls != 0) passed = 0;
+	if (name_mismatch && warning_calls != (quiet ? 0 : repetitions)) passed = 0;
+	if (stats_calls && stats_bytes != (size_t)stats_calls * fixture_length) passed = 0;
+	leaked_count = live_count; leaked_bytes = live_bytes;
+	/* Clean fixture leftovers AFTER recording failure; no leaks are concealed. */
+	for (i = 0; i < 64; i++) if (allocations[i].pointer != NULL) tracked_free(allocations[i].pointer);
+	printf("{\"scenario\":\"%s\",\"argc\":%d,\"quiet\":%d,\"by_name\":%d,\"passed\":%s,\"actual\":%d,\"expected\":%d,\"live_allocations\":%zu,\"live_bytes\":%zu,\"invalid_frees\":%zu,\"signature_calls\":%d,\"read_calls\":%d}\n",
+	    scenario, count, quiet, by_name, passed ? "true" : "false", actual, expected,
+	    leaked_count, leaked_bytes, invalid_frees, signature_calls, read_calls);
+	return (passed ? 0 : 1);
+}

--- a/tests/regressions/pr838/run.py
+++ b/tests/regressions/pr838/run.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Compile and exercise the complete metadata translation unit, offline.
+
+Requires a configured source checkout, a C99 compiler and GNU-compatible linker.
+No server, account, private key, production-source editing or network call occurs.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import tempfile
+
+
+def run() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--source', type=Path, help='Alternative metadata.c for baseline/control execution')
+    parser.add_argument('--root', type=Path, default=Path(__file__).resolve().parents[3])
+    parser.add_argument('--cc', default=os.environ.get('CC', 'cc'))
+    parser.add_argument('--sanitize', action='store_true')
+    parser.add_argument('--output', type=Path)
+    args = parser.parse_args()
+    root = args.root.resolve()
+    source = (args.source or root / 'tar/multitape/multitape_metadata.c').resolve()
+    if not source.is_file() or not (root / 'config.h').is_file():
+        parser.error('Run autoreconf -i and ./configure first; the selected source must exist.')
+    # These are the actual project headers, not copies of production structs.
+    includes = [root, root/'lib-platform', root/'lib/crypto', root/'libcperciva/crypto',
+                root/'libcperciva/util', root/'tar/chunks', root/'tar/storage', root/'tar/multitape']
+    rows: list[dict] = []
+    with tempfile.TemporaryDirectory(prefix='tarsnap-pr838-') as temp:
+        binary = Path(temp) / 'cleanup'
+        command = shlex.split(args.cc) + ['-std=c99', '-DHAVE_CONFIG_H', '-O1', '-g',
+            '-Wall', '-Wextra', '-Werror', '-ffunction-sections', '-fdata-sections']
+        if args.sanitize:
+            command += ['-fsanitize=address,undefined', '-fno-omit-frame-pointer']
+        command += ['-I'+str(p) for p in includes]
+        command += ['-DMETADATA_SOURCE='+json.dumps(str(source)), str(Path(__file__).with_name('cleanup.c')),
+                    str(root/'libcperciva/crypto/crypto_verify_bytes.c'), '-Wl,--gc-sections', '-o', str(binary)]
+        build = subprocess.run(command, text=True, capture_output=True, timeout=90)
+        if build.returncode:
+            print(build.stdout + build.stderr)
+            return 2
+        cases = [(scenario, count, quiet, by_name)
+                 for scenario in ('success', 'mismatch', 'hash-error')
+                 for count in (0, 1, 3) for quiet in (0, 1) for by_name in (0, 1)]
+        cases += [(scenario, 3, quiet, by_name)
+                  for scenario in ('repeat-mismatch', 'missing', 'read-corrupt', 'read-error',
+                                   'bad-signature', 'signature-error', 'short-signature',
+                                   'unterminated-name', 'truncated-argv', 'negative-argc', 'trailing-byte')
+                  for quiet in (0, 1) for by_name in (0, 1)]
+        cases += [('initial-hash-error', 3, quiet, 1) for quiet in (0, 1)]
+        cases += [(f'allocation-{number}', 3, 1, by_name) for number in range(1, 7) for by_name in (0, 1)]
+        for scenario, count, quiet, by_name in cases:
+            result = subprocess.run([str(binary), scenario, str(count), str(quiet), str(by_name)],
+                                    capture_output=True, text=True, timeout=15)
+            try:
+                row = json.loads(result.stdout)
+            except ValueError:
+                row = dict(scenario=scenario, argc=count, quiet=quiet, by_name=by_name, passed=False,
+                           diagnostic=result.stderr[-4000:])
+            row['exit_code'] = result.returncode
+            if result.returncode or result.stderr:
+                row['passed'] = False
+                if result.stderr:
+                    row['diagnostic'] = result.stderr[-4000:]
+            rows.append(row)
+    data = source.read_bytes()
+    report = {'source_sha256': hashlib.sha256(data).hexdigest(),
+              'source_git_blob': hashlib.sha1(b'blob '+str(len(data)).encode()+b'\0'+data).hexdigest(),
+              'compiler': args.cc, 'sanitized': args.sanitize, 'cases': len(rows),
+              'passed': sum(bool(row['passed']) for row in rows), 'results': rows}
+    text = json.dumps(report, indent=2) + '\n'
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding='utf-8')
+    print(json.dumps({key: value for key, value in report.items() if key != 'results'}))
+    for row in rows:
+        if not row['passed']:
+            print(json.dumps(row))
+    return 0 if report['passed'] == len(rows) else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(run())


### PR DESCRIPTION
Fixes #837.

## Summary

`multitape_metadata_get()` parses the metadata into the caller's `struct tapemetadata`,
then checks that the archive name recorded inside it hashes to the name of the metadata
file. Both failure exits of that check returned without releasing what
`multitape_metadata_dec()` had already allocated — `mdat->name`, the `mdat->argv` array,
and each `mdat->argv[i]`.

Callers only clean up after a successful get. `multitape_delete.c:116-139` is the
pattern: `multitape_metadata_free(&tmd)` is called on the `case 0` path, while the
non-zero cases jump to `err3`, which does not call it. So on a non-zero return the callee
owns the cleanup, and every other non-zero exit here honours that — only these two did
not.

## Reachability

The `crypto_verify_bytes()` mismatch is the corrupt-or-tampered metadata case: the name
stored inside the file does not hash to the file's own name. That is server-supplied
input, and it returns 2, which callers treat as an ordinary "this archive is corrupt"
outcome rather than a fatal error — so an operation walking several archives leaked once
per affected archive. The `crypto_hash_data()` failure above it is the same shape.

## Change

Two inline `multitape_metadata_free(mdat)` calls. `multitape_internal.h` is already
included at `:17`, and the function tolerates a partially populated structure.

Inline rather than new labels on purpose: `corrupt` and `err0` are both shared with
earlier exits that must not free `mdat` — `corrupt` is reached from `:322`, before the
parse has run at all — so moving the free to those labels would introduce a free of
never-initialised pointers.

## Relationship to other open items

Nothing else open touches `multitape_metadata.c`. Distinct from #716
(`archive_write_open_multitape()` in `tar/glue/`) and from my #825/#826, #827/#828,
#829/#830, #831/#832, #833/#834 and #835/#836, so this conflicts with none of them.

## Validation

Source-level only. The patched file differs from `0bf0b29` in this one hunk, brace and
paren counts balance, and no line exceeds 80 columns at 8-wide tabs. I have not compiled
or run it and have not constructed a metadata file whose recorded name disagrees with its
filename; as stated in #837 the change rests on the ownership `multitape_metadata_dec()`
establishes on success, the two exits that skip it, and the caller convention in
`multitape_delete.c`.

---

Per `AGENTS.md`: I am an LLM (Claude) working on behalf of the operator of this account.
I am available to discuss the change and to revise it in response to review feedback. I
understand bounties attach to the report rather than to a patch; this PR is here only to
make the fix directly reviewable, and it is entirely fine to take the change from #837
instead and close this.
