### PR TITLE
chunks_fsck_start: allocate with IMALLOC and free C->dir on error

### DIFF
--- a/keygen/keygen_actual.c
+++ b/keygen/keygen_actual.c
@@ -53,21 +53,21 @@ keygen_actual(struct register_internal * C, const char * keyfilename,
 
 	/* Sanity-check the user name. */
 	if (strlen(C->user) > 255) {
-		fprintf(stderr, "User name too long: %s\n", C->user);
+		warn0("User name too long: %s", C->user);
 		goto err0;
 	}
 	if (strlen(C->user) == 0) {
-		fprintf(stderr, "User name must be non-empty\n");
+		warn0("User name must be non-empty");
 		goto err0;
 	}
 
 	/* Sanity-check the machine name. */
 	if (strlen(C->name) > 255) {
-		fprintf(stderr, "Machine name too long: %s\n", C->name);
+		warn0("Machine name too long: %s", C->name);
 		goto err0;
 	}
 	if (strlen(C->name) == 0) {
-		fprintf(stderr, "Machine name must be non-empty\n");
+		warn0("Machine name must be non-empty");
 		goto err0;
 	}
 
@@ -80,7 +80,7 @@ keygen_actual(struct register_internal * C, const char * keyfilename,
 
 	/* Sanity-check the memory size. */
 	if (maxmem > SIZE_MAX) {
-		fprintf(stderr, "Passphrase memory size is too large\n");
+		warn0("Passphrase memory size is too large");
 		goto err0;
 	}
 

--- a/lib/netpacket/netpacket_op.c
+++ b/lib/netpacket/netpacket_op.c
@@ -520,6 +520,7 @@ int
 netpacket_close(NETPACKET_CONNECTION * NPC)
 {
 	struct netpacket_op * next;
+	int rc = 0;
 
 	/* Print statistics about network usage (if desired). */
 	if (tarsnap_opt_debug_network_stats)
@@ -527,8 +528,7 @@ netpacket_close(NETPACKET_CONNECTION * NPC)
 
 	/* Close the network protocol layer connection if we have one. */
 	if (NPC->NC != NULL)
-		if (netproto_close(NPC->NC))
-			goto err1;
+		rc = netproto_close(NPC->NC);
 
 	/* Free any queued operations. */
 	NPC->pending_current = NPC->pending_head;
@@ -544,20 +544,6 @@ netpacket_close(NETPACKET_CONNECTION * NPC)
 	/* Free the cookie. */
 	free(NPC);
 
-	/* Success! */
-	return (0);
-
-err1:
-	NPC->pending_current = NPC->pending_head;
-	while (NPC->pending_current != NULL) {
-		next = NPC->pending_current->next;
-		free(NPC->pending_current);
-		NPC->pending_current = next;
-	}
-
-	free(NPC->useragent);
-	free(NPC);
-
-	/* Failure! */
-	return (-1);
+	/* Report whether netproto_close() had any non-zero return. */
+	return ((rc == 0) ? 0 : -1);
 }

--- a/lib/netpacket/netpacket_op.c
+++ b/lib/netpacket/netpacket_op.c
@@ -521,6 +521,10 @@ netpacket_close(NETPACKET_CONNECTION * NPC)
 {
 	struct netpacket_op * next;
 
+	/* Print statistics about network usage (if desired). */
+	if (tarsnap_opt_debug_network_stats)
+		netpacket_printstats(NPC);
+
 	/* Close the network protocol layer connection if we have one. */
 	if (NPC->NC != NULL)
 		if (netproto_close(NPC->NC))
@@ -533,10 +537,6 @@ netpacket_close(NETPACKET_CONNECTION * NPC)
 		free(NPC->pending_current);
 		NPC->pending_current = next;
 	}
-
-	/* Print statistics about network usage (if desired). */
-	if (tarsnap_opt_debug_network_stats)
-		netpacket_printstats(NPC);
 
 	/* Free string allocated by strdup. */
 	free(NPC->useragent);

--- a/pkg/debian/upstream/metadata
+++ b/pkg/debian/upstream/metadata
@@ -1,0 +1,11 @@
+# Sort alphabetically by field name (ignoring the trailing ':').
+Bug-Database: https://github.com/Tarsnap/tarsnap/issues
+Bug-Submit: https://github.com/Tarsnap/tarsnap/issues/new
+Changelog: https://www.tarsnap.com/news.html
+Documentation: https://www.tarsnap.com/documentation.html
+FAQ: https://www.tarsnap.com/faq.html
+Other-References: https://www.tarsnap.com/support.html
+Registration: https://www.tarsnap.com/register.cgi
+Repository: https://github.com/Tarsnap/tarsnap.git
+Repository-Browse: https://github.com/Tarsnap/tarsnap
+Security-Contact: mailto:cperciva@tarsnap.com

--- a/tar/chunks/chunks_directory.c
+++ b/tar/chunks/chunks_directory.c
@@ -253,10 +253,6 @@ chunks_directory_read(const char * cachepath, void ** dir,
 		p->nrefs = le32dec(che.nrefs);
 		p->ncopies = le32dec(che.ncopies);
 
-		/* ... inserting them into the hash table... */
-		if (rwhashtab_insert(HT, p))
-			goto err4;
-
 #if UINT32_MAX > SSIZE_MAX
 		/* ... paranoid check for number of copies... */
 		if (p->ncopies > SSIZE_MAX)
@@ -265,16 +261,20 @@ chunks_directory_read(const char * cachepath, void ** dir,
 			    SSIZE_MAX);
 #endif
 
-		/* ... and updating the statistics. */
-		chunks_stats_add(stats_unique, p->len, p->zlen_flags, 1);
-		chunks_stats_add(stats_all, p->len, p->zlen_flags,
-		    (ssize_t)p->ncopies);
-
 		/* Sanity check. */
 		if ((p->len == 0) || (p->zlen_flags == 0) || (p->nrefs == 0)) {
 			warn0("on-disk directory is corrupt: %s", s);
 			goto err4;
 		}
+
+		/* ... inserting them into the hash table... */
+		if (rwhashtab_insert(HT, p))
+			goto err4;
+
+		/* ... and updating the statistics. */
+		chunks_stats_add(stats_unique, p->len, p->zlen_flags, 1);
+		chunks_stats_add(stats_all, p->len, p->zlen_flags,
+		    (ssize_t)p->ncopies);
 
 		/* Move to next record. */
 		if (statstape)

--- a/tar/chunks/chunks_directory.c
+++ b/tar/chunks/chunks_directory.c
@@ -262,7 +262,8 @@ chunks_directory_read(const char * cachepath, void ** dir,
 #endif
 
 		/* Sanity check. */
-		if ((p->len == 0) || (p->zlen_flags == 0) || (p->nrefs == 0)) {
+		if ((p->len == 0) || (p->zlen_flags == 0) ||
+		    ((p->zlen_flags & CHDATA_FLAGS) != 0) || (p->nrefs == 0)) {
 			warn0("on-disk directory is corrupt: %s", s);
 			goto err4;
 		}

--- a/tar/chunks/chunks_stats.c
+++ b/tar/chunks/chunks_stats.c
@@ -1,6 +1,5 @@
 #include "platform.h"
 
-#include <errno.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -9,6 +8,7 @@
 
 #include "chunks_internal.h"
 #include "hexify.h"
+#include "imalloc.h"
 #include "rwhashtab.h"
 #include "storage.h"
 
@@ -124,13 +124,7 @@ chunks_fsck_start(uint64_t machinenum, const char * cachepath)
 		goto err2;
 
 	/* Construct a chunkdata_statstape structure for each file. */
-	if (nfiles > SIZE_MAX / sizeof(struct chunkdata_statstape)) {
-		errno = ENOMEM;
-		free(flist);
-		goto err2;
-	}
-	if ((C->dir =
-	    malloc(nfiles * sizeof(struct chunkdata_statstape))) == NULL) {
+	if (IMALLOC(C->dir, nfiles, struct chunkdata_statstape)) {
 		free(flist);
 		goto err2;
 	}
@@ -146,12 +140,12 @@ chunks_fsck_start(uint64_t machinenum, const char * cachepath)
 	/* Create an empty chunk directory. */
 	C->HT = rwhashtab_init(offsetof(struct chunkdata, hash), 32);
 	if (C->HT == NULL)
-		goto err2;
+		goto err3;
 
 	/* Insert the chunkdata structures we constructed above. */
 	for (file = 0; file < nfiles; file++) {
 		if (rwhashtab_insert(C->HT, &C->dir[file]))
-			goto err3;
+			goto err4;
 	}
 
 	/* Zero statistics. */
@@ -162,8 +156,10 @@ chunks_fsck_start(uint64_t machinenum, const char * cachepath)
 	/* Success! */
 	return (C);
 
-err3:
+err4:
 	rwhashtab_free(C->HT);
+err3:
+	free(C->dir);
 err2:
 	free(C->cachepath);
 err1:

--- a/tar/glue/archive_multitape.c
+++ b/tar/glue/archive_multitape.c
@@ -295,7 +295,7 @@ archive_multitape_copy(struct archive * ina, void * read_cookie,
 			/* Write it out to the new archive. */
 			writelen = archive_write_data(a, buff, (size_t)lenread);
 			if (writelen < lenread)
-				return (-1);
+				return (ARCHIVE_MULTITAPE_COPY_FATAL);
 
 			/* Adjust the remaining entry length and continue. */
 			entrylen -= lenread;
@@ -317,12 +317,12 @@ archive_multitape_copy(struct archive * ina, void * read_cookie,
 		/* Attempt to write the chunk via the fast path. */
 		writelen = writetape_writechunk(write_cookie, ch);
 		if (writelen < 0)
-			return (-1);
+			return (ARCHIVE_MULTITAPE_COPY_FATAL);
 		if (writelen == 0)
 			goto nochunk;
 		if (writelen != lenread) {
 			warn0("chunk write size != chunk read size?");
-			return (-1);
+			return (ARCHIVE_MULTITAPE_COPY_FATAL);
 		}
 
 		/*
@@ -330,7 +330,7 @@ archive_multitape_copy(struct archive * ina, void * read_cookie,
 		 * first since a failure there is fatal.
 		 */
 		if (archive_write_skip(a, writelen))
-			return (-1);
+			return (ARCHIVE_MULTITAPE_COPY_FATAL);
 		if (archive_read_advance(ina, lenread))
 			return (-2);
 
@@ -367,7 +367,7 @@ nochunk:
 			return (-2);
 		writelen = archive_write_data(a, buff, 1);
 		if (writelen < 1)
-			return (-1);
+			return (ARCHIVE_MULTITAPE_COPY_FATAL);
 	}
 
 	/* Success! */

--- a/tar/glue/archive_multitape.c
+++ b/tar/glue/archive_multitape.c
@@ -267,7 +267,7 @@ archive_multitape_copy(struct archive * ina, void * read_cookie,
 	if ((entrylen = archive_read_get_entryleft(ina)) < 0) {
 		archive_set_error(ina, ENOSYS,
 		    "read_get_entryleft not supported");
-		return (-2);
+		return (ARCHIVE_MULTITAPE_COPY_READ_ERROR);
 	}
 
 	/* Copy data. */
@@ -275,7 +275,7 @@ archive_multitape_copy(struct archive * ina, void * read_cookie,
 		/* Is there data buffered by libarchive? */
 		if ((backloglen = archive_read_get_backlog(ina)) < 0) {
 			warn0("Error reading libarchive data backlog");
-			return (-2);
+			return (ARCHIVE_MULTITAPE_COPY_READ_ERROR);
 		}
 		if (backloglen > 0) {
 			/* Drain some data from libarchive. */
@@ -287,10 +287,10 @@ archive_multitape_copy(struct archive * ina, void * read_cookie,
 			if (lenread == 0) {
 				warn0("libarchive claims data backlog,"
 				    " but no data can be read?");
-				return (-2);
+				return (ARCHIVE_MULTITAPE_COPY_READ_ERROR);
 			}
 			if (lenread < 0)
-				return (-2);
+				return (ARCHIVE_MULTITAPE_COPY_READ_ERROR);
 
 			/* Write it out to the new archive. */
 			writelen = archive_write_data(a, buff, (size_t)lenread);
@@ -305,11 +305,11 @@ archive_multitape_copy(struct archive * ina, void * read_cookie,
 		/* Attempt to read a chunk for fast-pathing. */
 		lenread = readtape_readchunk(read_cookie, &ch);
 		if (lenread < 0)
-			return (-2);
+			return (ARCHIVE_MULTITAPE_COPY_READ_ERROR);
 		if (lenread > entrylen) {
 			warn0("readchunk returned chunk beyond end"
 			    " of archive entry?");
-			return (-2);
+			return (ARCHIVE_MULTITAPE_COPY_READ_ERROR);
 		}
 		if (lenread == 0)
 			goto nochunk;
@@ -332,12 +332,12 @@ archive_multitape_copy(struct archive * ina, void * read_cookie,
 		if (archive_write_skip(a, writelen))
 			return (ARCHIVE_MULTITAPE_COPY_FATAL);
 		if (archive_read_advance(ina, lenread))
-			return (-2);
+			return (ARCHIVE_MULTITAPE_COPY_READ_ERROR);
 
 		/* We don't need to see this chunk again. */
 		if (readtape_skip(read_cookie, lenread) != lenread) {
 			warn0("could not skip read data?");
-			return (-2);
+			return (ARCHIVE_MULTITAPE_COPY_READ_ERROR);
 		}
 
 		/* We've done part of the entry. */
@@ -364,7 +364,7 @@ nochunk:
 		if (lenread == 0)
 			break;
 		if (lenread < 0)
-			return (-2);
+			return (ARCHIVE_MULTITAPE_COPY_READ_ERROR);
 		writelen = archive_write_data(a, buff, 1);
 		if (writelen < 1)
 			return (ARCHIVE_MULTITAPE_COPY_FATAL);

--- a/tar/glue/archive_multitape.c
+++ b/tar/glue/archive_multitape.c
@@ -28,9 +28,15 @@ read_read(struct archive * a, void * cookie, const void ** buffer)
 	lenread = readtape_read(d, buffer);
 	if (lenread < 0) {
 		archive_set_error(a, errno, "Error reading archive");
-		return (ARCHIVE_FATAL);
-	} else
-		return (lenread);
+		goto err0;
+	}
+
+	/* Success! */
+	return (lenread);
+
+err0:
+	/* Failure! */
+	return (ARCHIVE_FATAL);
 }
 
 static off_t
@@ -42,9 +48,15 @@ read_skip(struct archive * a, void * cookie, off_t request)
 	skiplen = readtape_skip(d, request);
 	if (skiplen < 0) {
 		archive_set_error(a, errno, "Error reading archive");
-		return (ARCHIVE_FATAL);
-	} else
-		return (skiplen);
+		goto err0;
+	}
+
+	/* Success! */
+	return (skiplen);
+
+err0:
+	/* Failure! */
+	return (ARCHIVE_FATAL);
 }
 
 static int
@@ -54,9 +66,15 @@ read_close(struct archive * a, void * cookie)
 
 	if (readtape_close(d)) {
 		archive_set_error(a, errno, "Error closing archive");
-		return (ARCHIVE_FATAL);
-	} else
-		return (ARCHIVE_OK);
+		goto err0;
+	}
+
+	/* Success! */
+	return (ARCHIVE_OK);
+
+err0:
+	/* Failure! */
+	return (ARCHIVE_FATAL);
 }
 
 static ssize_t
@@ -72,13 +90,23 @@ write_write(struct archive * a, void * cookie, const void * buffer,
 	writelen = writetape_write(d, buffer, nbytes);
 	if (writelen < 0) {
 		archive_set_error(a, errno, "Error writing archive");
-		return (ARCHIVE_FATAL);
+		goto err0;
 	} else if (writelen == 0) {
 		archive_clear_error(a);
 		archive_set_error(a, 0, "Archive truncated");
-		return (ARCHIVE_WARN);
-	} else
-		return ((ssize_t)nbytes);
+		goto err_warn;
+	}
+
+	/* Success! */
+	return ((ssize_t)nbytes);
+
+err_warn:
+	/* Partial failure! */
+	return (ARCHIVE_WARN);
+
+err0:
+	/* Failure! */
+	return (ARCHIVE_FATAL);
 }
 
 static int
@@ -88,9 +116,15 @@ write_close(struct archive * a, void * cookie)
 
 	if (writetape_close(d)) {
 		archive_set_error(a, errno, "Error closing archive");
-		return (ARCHIVE_FATAL);
-	} else
-		return (ARCHIVE_OK);
+		goto err0;
+	}
+
+	/* Success! */
+	return (ARCHIVE_OK);
+
+err0:
+	/* Failure! */
+	return (ARCHIVE_FATAL);
 }
 
 /**
@@ -110,13 +144,18 @@ archive_read_open_multitape(struct archive * a, uint64_t machinenum,
 
 	if ((d = readtape_open(machinenum, tapename)) == NULL) {
 		archive_set_error(a, errno, "Error opening archive");
-		return (NULL);
+		goto err0;
 	}
 
 	if (archive_read_open2(a, d, NULL, read_read, read_skip, read_close))
-		return (NULL);
-	else
-		return (d);
+		goto err0;
+
+	/* Success! */
+	return (d);
+
+err0:
+	/* Failure! */
+	return (NULL);
 }
 
 /**
@@ -145,14 +184,20 @@ archive_write_open_multitape(struct archive * a, uint64_t machinenum,
 	    argc, argv, printstats, dryrun, creationtime,
 	    csv_filename, storage_modified)) == NULL) {
 		archive_set_error(a, errno, "Error creating new archive");
-		return (NULL);
+		goto err0;
 	}
 
 	if (archive_write_open(a, d, NULL, write_write, write_close)) {
 		writetape_free(d);
-		return (NULL);
-	} else
-		return (d);
+		goto err0;
+	}
+
+	/* Success! */
+	return (d);
+
+err0:
+	/* Failure! */
+	return (NULL);
 }
 
 /**
@@ -166,9 +211,15 @@ archive_write_multitape_setmode(struct archive * a, void * cookie, int mode)
 
 	if (writetape_setmode(d, mode)) {
 		archive_set_error(a, errno, "Error writing archive");
-		return (ARCHIVE_FATAL);
-	} else
-		return (ARCHIVE_OK);
+		goto err0;
+	}
+
+	/* Success! */
+	return (ARCHIVE_OK);
+
+err0:
+	/* Failure! */
+	return (ARCHIVE_FATAL);
 }
 
 /**

--- a/tar/glue/archive_multitape.h
+++ b/tar/glue/archive_multitape.h
@@ -7,6 +7,7 @@
 #include "archive.h"
 
 #define ARCHIVE_MULTITAPE_COPY_FATAL (-1)
+#define ARCHIVE_MULTITAPE_COPY_READ_ERROR (-2)
 
 /**
  * archive_read_open_multitape(a, machinenum, tapename):

--- a/tar/glue/archive_multitape.h
+++ b/tar/glue/archive_multitape.h
@@ -6,6 +6,8 @@
 
 #include "archive.h"
 
+#define ARCHIVE_MULTITAPE_COPY_FATAL (-1)
+
 /**
  * archive_read_open_multitape(a, machinenum, tapename):
  * Open the multitape tape ${tapename} for reading (and skipping) and

--- a/tar/multitape/multitape_stats.c
+++ b/tar/multitape/multitape_stats.c
@@ -244,12 +244,12 @@ statstape_printlist_item(TAPE_S * d, const uint8_t tapehash[32], int verbose,
 		if (verbose == 0) {
 			/* We're finished; print archive separator and quit. */
 			if (print_separator(stdout, "\n", print_nulls, 1))
-				goto err1;
+				goto err0;
 			goto done;
 		} else {
 			/* We have more fields; print field separator. */
 			if (print_separator(stdout, "\t", print_nulls, 2))
-				goto err1;
+				goto err0;
 		}
 	}
 

--- a/tar/write.c
+++ b/tar/write.c
@@ -681,7 +681,7 @@ append_archive(struct bsdtar *bsdtar, struct archive *a, struct archive *ina,
 			    bsdtar->write_cookie)) {
 			case ARCHIVE_MULTITAPE_COPY_FATAL:
 				goto err_fatal;
-			case -2:
+			case ARCHIVE_MULTITAPE_COPY_READ_ERROR:
 				goto err_read;
 			}
 		}

--- a/tar/write.c
+++ b/tar/write.c
@@ -679,7 +679,7 @@ append_archive(struct bsdtar *bsdtar, struct archive *a, struct archive *ina,
 		} else {
 			switch (archive_multitape_copy(ina, cookie, a,
 			    bsdtar->write_cookie)) {
-			case -1:
+			case ARCHIVE_MULTITAPE_COPY_FATAL:
 				goto err_fatal;
 			case -2:
 				goto err_read;

--- a/tests/unit/allocations.h
+++ b/tests/unit/allocations.h
@@ -1,0 +1,85 @@
+#ifndef TEST_ALLOCATIONS_H_
+#define TEST_ALLOCATIONS_H_
+
+#include <assert.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Faults apply only to source compiled with the explicit macros below. */
+static void * unit_allocations[256];
+static size_t unit_live, unit_requests, unit_fail_at;
+
+static inline void *
+unit_malloc(size_t len)
+{
+	void * p;
+	size_t i;
+
+	unit_requests++;
+	if (unit_fail_at != 0 && unit_requests == unit_fail_at) {
+		errno = ENOMEM;
+		return (NULL);
+	}
+	/* A conforming allocator may return NULL for a zero-size request. */
+	if (len == 0)
+		return (NULL);
+	if ((p = malloc(len)) == NULL)
+		return (NULL);
+	for (i = 0; i < 256; i++) {
+		if (unit_allocations[i] == NULL) {
+			unit_allocations[i] = p;
+			unit_live++;
+			return (p);
+		}
+	}
+	abort();
+}
+
+static inline void
+unit_free(void * p)
+{
+	size_t i;
+
+	if (p != NULL) {
+		for (i = 0; i < 256; i++) {
+			if (unit_allocations[i] == p) {
+				unit_allocations[i] = NULL;
+				assert(unit_live > 0);
+				unit_live--;
+				break;
+			}
+		}
+	}
+	free(p);
+}
+
+static inline char *
+unit_strdup(const char * s)
+{
+	size_t len = strlen(s) + 1;
+	char * p = unit_malloc(len);
+
+	if (p != NULL)
+		memcpy(p, s, len);
+	return (p);
+}
+
+static inline void *
+unit_memset(void * p, int value, size_t len)
+{
+	/* Even a zero-length memset requires a valid destination. */
+	assert(p != NULL);
+	return (memset(p, value, len));
+}
+
+static inline void
+unit_reset(size_t fail_at)
+{
+	assert(unit_live == 0);
+	unit_requests = 0;
+	unit_fail_at = fail_at;
+}
+
+#endif /* !TEST_ALLOCATIONS_H_ */

--- a/tests/unit/chunks-fsck.c
+++ b/tests/unit/chunks-fsck.c
@@ -1,0 +1,125 @@
+/* Actual initialization/error ladders with tracked allocation ownership. */
+#include "platform.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "allocations.h"
+
+#define malloc unit_malloc
+#define strdup unit_strdup
+#define free unit_free
+#include "../../tar/chunks/chunks_stats.c"
+#undef free
+#undef strdup
+#undef malloc
+#include "../../tar/chunks/chunks_stats_internal.c"
+
+static size_t count, inserted;
+static int mode, scenarios;
+
+int
+storage_directory_read(uint64_t machine, char class, int key,
+    uint8_t ** files, size_t * nfiles)
+{
+	size_t i;
+
+	assert(machine == 17 && class == 'c' && key == 0);
+	if (mode == 3)
+		return (-1);
+	*nfiles = count;
+	*files = count == 0 ? NULL : unit_malloc(count * 32);
+	assert(count == 0 || *files != NULL);
+	for (i = 0; i < count; i++)
+		memset(*files + i * 32, (int)(i + 1), 32);
+	return (0);
+}
+
+RWHASHTAB *
+rwhashtab_init(size_t offset, size_t length)
+{
+	assert(offset == offsetof(struct chunkdata, hash) && length == 32);
+	return (mode == 5 ? NULL : unit_malloc(1));
+}
+
+int
+rwhashtab_insert(RWHASHTAB * table, void * record)
+{
+	struct chunkdata_statstape * c = record;
+
+	assert(table != NULL && record != NULL);
+	assert(c->d.hash[0] == inserted + 1);
+	assert(c->d.hash[31] == inserted + 1);
+	assert(c->d.len == 0 && c->d.zlen_flags == 0);
+	assert(c->d.nrefs == 0 && c->d.ncopies == 0);
+	inserted++;
+	if ((mode == 6 && inserted == 1) ||
+	    (mode == 7 && inserted == 2))
+		return (-1);
+	return (0);
+}
+
+void
+rwhashtab_free(RWHASHTAB * table)
+{
+	unit_free(table);
+}
+
+void
+chunks_directory_free(RWHASHTAB * table, void * dir)
+{
+	rwhashtab_free(table);
+	unit_free(dir);
+}
+
+static void
+scenario(size_t nfiles, int failure)
+{
+	CHUNKS_S * c;
+	size_t fail_at = failure == 1 ? 1 : (failure == 2 ? 2 : 0);
+
+	if (failure == 4)
+		fail_at = 4;
+	unit_reset(fail_at);
+	count = nfiles;
+	mode = failure;
+	inserted = 0;
+	c = chunks_fsck_start(17, "fixture-cache");
+	assert((c == NULL) == (failure != 0));
+	if (c != NULL) {
+		assert(strcmp(c->cachepath, "fixture-cache") == 0);
+		assert((c->dir == NULL) == (nfiles == 0));
+		assert(inserted == nfiles);
+		assert(c->stats_total.nchunks == 0);
+		assert(c->stats_unique.s_len == 0 && c->stats_extra.s_zlen == 0);
+		chunks_stats_free(c);
+	}
+	/* Includes the file list, directory, cookie, path and fake table. */
+	assert(unit_live == 0);
+	scenarios++;
+}
+
+int
+main(void)
+{
+	size_t n;
+	int failure;
+
+	for (n = 0; n <= 4; n++) {
+		scenario(n, 0);
+		for (failure = 1; failure <= 3; failure++)
+			scenario(n, failure);
+		if (n != 0) {
+			for (failure = 4; failure <= 6; failure++)
+				scenario(n, failure);
+		}
+		if (n >= 2)
+			scenario(n, 7);
+	}
+	chunks_stats_free(NULL);
+	printf("PASS: %d empty-list and allocation-cleanup scenarios\n", scenarios);
+	return (0);
+}

--- a/tests/unit/chunks-fsck.md
+++ b/tests/unit/chunks-fsck.md
@@ -1,0 +1,28 @@
+# Regression: fsck chunk-list allocation cleanup
+
+Supports PR842 at original head `8a5886951fc15d66bf50f6255545580ee1ad43c3`.
+
+From a configured Linux/GCC checkout run:
+
+```sh
+sh tests/unit/chunks-fsck.sh
+```
+
+An out-of-tree configured build directory may be passed as the first argument.
+The standalone tests are not automatically invoked by `make test`.
+
+There are 35 scenarios: NULL-returning zero-size allocation, populated
+initialization, allocation/listing/table-initialization/insertion failures,
+and tracked cleanup. The actual initialization and error ladders execute;
+storage and hash-table insertion are controlled fixtures. This is not a live
+account or complete fsck run.
+
+The submitted correction passes; common base
+`0bf0b299fed91139044c81cc6fcdc5521c34d235` fails the empty-list check.
+Removing directory cleanup independently fails allocation accounting.
+Production source is unchanged by this follow-up.
+
+Prepared by ChatGPT ASTRA-TEN at the account owner's request. C retains the
+original report841, implementation and discovery credit. No new bounty claim.
+Review questions can be addressed in active follow-up sessions; no continuous
+autonomous monitoring is represented.

--- a/tests/unit/chunks-fsck.sh
+++ b/tests/unit/chunks-fsck.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Standalone GNU/POSIX regression. Configure first; no account is required.
+set -eu
+ulimit -c 0
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+build=${1:-"$root"}
+if [ ! -f "$build/config.h" ]; then
+    echo "Configure the project first, or pass a configured build directory." >&2
+    exit 2
+fi
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+set -- -I"$build"
+set -- "$@" -I"$root/lib"
+set -- "$@" -I"$root/lib-platform"
+set -- "$@" -I"$root/lib-platform/util"
+set -- "$@" -I"$root/lib/crypto"
+set -- "$@" -I"$root/lib/datastruct"
+set -- "$@" -I"$root/lib/keyfile"
+set -- "$@" -I"$root/lib/netpacket"
+set -- "$@" -I"$root/lib/netproto"
+set -- "$@" -I"$root/lib/network"
+set -- "$@" -I"$root/lib/util"
+set -- "$@" -I"$root/libarchive"
+set -- "$@" -I"$root/libcperciva/crypto"
+set -- "$@" -I"$root/libcperciva/datastruct"
+set -- "$@" -I"$root/libcperciva/util"
+set -- "$@" -I"$root/tar"
+set -- "$@" -I"$root/tar/ccache"
+set -- "$@" -I"$root/tar/chunks"
+set -- "$@" -I"$root/tar/multitape"
+set -- "$@" -I"$root/tar/storage"
+${CC:-cc} -DHAVE_CONFIG_H -DUSERAGENT='"unit-regression"' \
+    -std=c99 -O2 -Wall -Wextra -Werror -ffunction-sections -fdata-sections \
+    "$@" "$root/tests/unit/chunks-fsck.c" \
+    -Wl,--gc-sections -o "$tmp/chunks-fsck"
+"$tmp/chunks-fsck"


### PR DESCRIPTION
Fixes #841.

Two defects in `chunks_fsck_start()`, both described in that issue.

**An empty machine fails `--fsck`.** `nfiles` comes from the server's chunk listing and is legitimately zero for a machine that has never stored a chunk, or whose archives have all been deleted — `callback_directory_response()` accepts a `packetbuf[0] == 0` "no more files" response carrying zero entries. The site open-coded a `SIZE_MAX` overflow check and then treated a `NULL` from `malloc(nfiles * sizeof(...))` as failure, and `malloc(0)` is permitted to return `NULL` without setting `errno`.

`phase1()` in `tar/multitape/multitape_fsck.c` does the identical thing on the metadata arm of the same command and uses `IMALLOC`, whose contract is that a zero count returns `NULL` and is not an error, and which performs the overflow check itself. This makes the chunk arm agree with it, so the open-coded check and `<errno.h>` are no longer needed here.

**`C->dir` was leaked on two error paths.** Once allocated it is owned by the cookie — `chunks_fsck_end()` and `chunks_stats_free()` both release it through `chunks_directory_free()` — but a failure from `rwhashtab_init()` or `rwhashtab_insert()` returned without freeing it. `err2` is also reached from two points before `C->dir` exists, so this adds a label rather than a `free()` to `err2`; the existing labels shift by one.

With `nfiles == 0`, `C->dir` is now `NULL`. That is safe on every path that touches it: both `for (file = 0; file < nfiles; file++)` loops do not execute, and `chunks_directory_free()` ends in a plain `free(dir)`.

## What I did not exercise

I did not build or run tarsnap, and did not run `--fsck` against a server; there is no test in the tree covering `chunks_fsck_start()` with an empty chunk listing. Reachability of `nfiles == 0` is read from `callback_directory_response()` rather than observed on the wire, and the `malloc(0)` behaviour is the standard's allowance rather than something reproduced against a specific libc — on glibc `malloc(0)` returns non-NULL, so that defect is latent there and would bite where `malloc(0)` returns `NULL`. The leak is unconditional and platform-independent.
