### PR TITLE
storage_directory_read: hand the list to the caller after the close succeeds

### DIFF
--- a/tar/storage/storage_directory.c
+++ b/tar/storage/storage_directory.c
@@ -70,13 +70,13 @@ storage_directory_read(uint64_t machinenum, char class, int key,
 	if (network_spin(&C.done))
 		goto err2;
 
-	/* Return results. */
-	*flist = C.flist;
-	*nfiles = C.nfiles;
-
 	/* Close netpacket connection. */
 	if (netpacket_close(C.NPC))
 		goto err1;
+
+	/* Return results. */
+	*flist = C.flist;
+	*nfiles = C.nfiles;
 
 	/* Success! */
 	return (0);

--- a/tests/unit/storage-directory.c
+++ b/tests/unit/storage-directory.c
@@ -1,0 +1,197 @@
+/* Exercise the actual output-ownership boundary; transport is a fixture. */
+#include "platform.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void * allocated;
+static int freed;
+static void *
+observed_malloc(size_t len)
+{
+	void * p = malloc(len);
+
+	assert(allocated == NULL);
+	allocated = p;
+	return (p);
+}
+static void
+observed_free(void * p)
+{
+	if (p != NULL && p == allocated)
+		assert(freed++ == 0);
+	free(p);
+}
+
+#define malloc observed_malloc
+#define free observed_free
+#include "../../tar/storage/storage_directory.c"
+#undef free
+#undef malloc
+
+static int mode, closes, operations, spins;
+static size_t count;
+static int dummy;
+
+NETPACKET_CONNECTION *
+netpacket_open(const char * agent)
+{
+	assert(agent != NULL);
+	return (mode == 1 ? NULL : (NETPACKET_CONNECTION *)&dummy);
+}
+
+int
+netpacket_close(NETPACKET_CONNECTION * npc)
+{
+	assert(npc == (NETPACKET_CONNECTION *)&dummy);
+	closes++;
+	return (mode == 4 ? -1 : 0);
+}
+
+static void * operation_cookie;
+
+int
+netpacket_op(NETPACKET_CONNECTION * npc, sendpacket_callback * send,
+    void * cookie)
+{
+	int rc;
+
+	assert(npc == (NETPACKET_CONNECTION *)&dummy);
+	operations++;
+	operation_cookie = cookie;
+	rc = send(cookie, npc);
+	operation_cookie = NULL;
+	return (mode == 2 ? -1 : rc);
+}
+
+int
+netpacket_transaction_getnonce(NETPACKET_CONNECTION * npc, uint64_t machine,
+    handlepacket_callback * callback)
+{
+	uint8_t nonce[32] = {0};
+
+	assert(machine == 17);
+	return (callback(operation_cookie, npc, NETWORK_STATUS_OK,
+	    NETPACKET_TRANSACTION_GETNONCE_RESPONSE, nonce, sizeof(nonce)));
+}
+
+int
+crypto_entropy_read(uint8_t * buf, size_t len)
+{
+	memset(buf, 0, len);
+	return (0);
+}
+
+int
+crypto_hash_data_2(int key, const uint8_t * a, size_t alen,
+    const uint8_t * b, size_t blen, uint8_t out[32])
+{
+	(void)key;
+	assert(a != NULL && b != NULL && alen == 32 && blen == 32);
+	memset(out, 0, 32);
+	return (0);
+}
+
+int
+netpacket_hmac_verify(uint8_t type, const uint8_t nonce[32],
+    const uint8_t * buf, size_t len, int key)
+{
+	(void)nonce;
+	(void)key;
+	assert(type == NETPACKET_DIRECTORY_RESPONSE && buf != NULL);
+	assert(len == 38 + 32 * count);
+	/* This tests ownership, not authentication; no real keys are used. */
+	return (0);
+}
+
+int
+netpacket_directory(NETPACKET_CONNECTION * npc, uint64_t machine,
+    uint8_t class, const uint8_t start[32], const uint8_t snonce[32],
+    const uint8_t cnonce[32], int key, handlepacket_callback * callback)
+{
+	uint8_t packet[70 + 3 * 32] = {0};
+	size_t i;
+
+	(void)snonce;
+	(void)cnonce;
+	assert(machine == 17 && class == 'm' && (key == 0 || key == 1));
+	packet[1] = class;
+	memcpy(packet + 2, start, 32);
+	be32enc(packet + 34, (uint32_t)count);
+	for (i = 0; i < count; i++)
+		packet[38 + i * 32] = (uint8_t)(i + 1);
+	return (callback(operation_cookie, npc, NETWORK_STATUS_OK,
+	    NETPACKET_DIRECTORY_RESPONSE, packet, 70 + count * 32));
+}
+
+int
+netpacket_directory_readmore(NETPACKET_CONNECTION * npc,
+    handlepacket_callback * callback)
+{
+	(void)npc;
+	(void)callback;
+	abort();
+}
+
+void
+netproto_printerr_internal(int status)
+{
+	(void)status;
+	abort();
+}
+
+void
+libcperciva_warnx(const char * fmt, ...)
+{
+	(void)fmt;
+	abort();
+}
+
+int
+network_spin(int * done)
+{
+	assert(*done == 1);
+	spins++;
+	return (mode == 3 ? -1 : 0);
+}
+
+int
+main(void)
+{
+	uint8_t sentinel, * files;
+	size_t nfiles;
+	int key, rc;
+
+	for (key = 0; key <= 1; key++) {
+		for (count = 0; count <= 3; count += 3) {
+			for (mode = 0; mode <= 4; mode++) {
+				allocated = NULL;
+				freed = closes = operations = spins = 0;
+				files = &sentinel;
+				nfiles = 91;
+				rc = storage_directory_read(17, 'm', key,
+				    &files, &nfiles);
+				assert(rc == (mode == 0 ? 0 : -1));
+				assert(closes == (mode == 1 ? 0 : 1));
+				assert(operations == (mode == 1 ? 0 : 1));
+				assert(spins == (mode == 1 || mode == 2 ? 0 : 1));
+				if (mode == 0) {
+					assert(nfiles == count && files == allocated);
+					assert(freed == 0);
+					if (count != 0)
+						assert(files[(count - 1) * 32] == count);
+					observed_free(files);
+				} else {
+					/* Neither out-parameter is published on error. */
+					assert(files == &sentinel && nfiles == 91);
+				}
+				assert(freed == (mode != 1 && count != 0 ? 1 : 0));
+			}
+		}
+	}
+	puts("PASS: 20 directory ownership, cleanup and output scenarios");
+	return (0);
+}

--- a/tests/unit/storage-directory.md
+++ b/tests/unit/storage-directory.md
@@ -1,0 +1,29 @@
+# Regression: directory output ownership
+
+Supports PR846 at original head `e5f5f7e215427476a3eba2b5778a56c7174504fc`.
+
+From a configured Linux/GCC checkout run:
+
+```sh
+sh tests/unit/storage-directory.sh
+```
+
+An out-of-tree configured build directory may be passed as the first argument.
+This standalone regression is not automatically invoked by `make test`.
+
+Twenty scenarios execute the real request/response and public API code with
+both key choices, empty/populated synthetic responses, open/request/spin/close
+failures, unchanged output sentinels on error, and correct freeing/handoff.
+Nonce/hash/authentication providers are controlled fixture boundaries, not
+cryptographic validation or hosted server tests.
+
+The submitted correction passes; common base
+`0bf0b299fed91139044c81cc6fcdc5521c34d235` fails the unchanged-output assertion
+on a close failure. This remains the latent API-contract defect described in
+the original report; no new in-tree misuse is claimed. Production source is
+unchanged by this follow-up.
+
+Prepared by ChatGPT ASTRA-TEN at the account owner's request. C retains the
+original report845, implementation and discovery credit. No new bounty claim.
+Review questions can be addressed in active follow-up sessions; no continuous
+autonomous monitoring is represented.

--- a/tests/unit/storage-directory.sh
+++ b/tests/unit/storage-directory.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Standalone GNU/POSIX regression. Configure first; no account is required.
+set -eu
+ulimit -c 0
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+build=${1:-"$root"}
+if [ ! -f "$build/config.h" ]; then
+    echo "Configure the project first, or pass a configured build directory." >&2
+    exit 2
+fi
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+set -- -I"$build"
+set -- "$@" -I"$root/lib"
+set -- "$@" -I"$root/lib-platform"
+set -- "$@" -I"$root/lib-platform/util"
+set -- "$@" -I"$root/lib/crypto"
+set -- "$@" -I"$root/lib/datastruct"
+set -- "$@" -I"$root/lib/keyfile"
+set -- "$@" -I"$root/lib/netpacket"
+set -- "$@" -I"$root/lib/netproto"
+set -- "$@" -I"$root/lib/network"
+set -- "$@" -I"$root/lib/util"
+set -- "$@" -I"$root/libarchive"
+set -- "$@" -I"$root/libcperciva/crypto"
+set -- "$@" -I"$root/libcperciva/datastruct"
+set -- "$@" -I"$root/libcperciva/util"
+set -- "$@" -I"$root/tar"
+set -- "$@" -I"$root/tar/ccache"
+set -- "$@" -I"$root/tar/chunks"
+set -- "$@" -I"$root/tar/multitape"
+set -- "$@" -I"$root/tar/storage"
+${CC:-cc} -DHAVE_CONFIG_H -DUSERAGENT='"unit-regression"' \
+    -std=c99 -O2 -Wall -Wextra -Werror -ffunction-sections -fdata-sections \
+    "$@" "$root/tests/unit/storage-directory.c" \
+    -Wl,--gc-sections -o "$tmp/storage-directory"
+"$tmp/storage-directory"


### PR DESCRIPTION
Fixes #845.

`storage_directory_read()` assigned `*flist = C.flist;` and then, if `netpacket_close()` failed, jumped to `err1` and freed that pointer — returning `-1` after having already published it to the caller.

Moving the handoff below the close makes the out-parameters written only on success, so `err1`'s `free()` owns what it frees on every path that reaches it. `err2` was already correct; it is only reachable before the assignment.

No behaviour changes on the success path, and nothing else in the function moves.

## What I did not exercise

I did not build or run tarsnap, and did not induce a `netpacket_close()` failure, so I have not observed this path executing — the reasoning is from the source. As noted in the issue, none of the five in-tree callers frees or reads `flist` on a non-zero return, so this is a latent contract defect rather than a live double-free today.
