### PR TITLE
storage_transaction_commit: record the modification once the server confirms

### DIFF
--- a/tar/storage/storage_transaction.c
+++ b/tar/storage/storage_transaction.c
@@ -701,12 +701,15 @@ storage_transaction_commit(uint64_t machinenum, const uint8_t seqnum[32],
 		sleep(1);
 	} while (1);
 
+	/*
+	 * The server has confirmed the commit, so the data on the server has
+	 * been modified whether or not the rest of this function succeeds.
+	 */
+	*storage_modified = 1;
+
 	/* Close netpacket connection. */
 	if (netpacket_close(NPC))
 		goto err0;
-
-	/* We've modified the storage. */
-	*storage_modified = 1;
 
 	/* Success! */
 	return (0);

--- a/tests/unit/storage-commit.c
+++ b/tests/unit/storage-commit.c
@@ -1,0 +1,134 @@
+/* Actual commit/response code; a synthetic packet provider owns no account. */
+#include "platform.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static unsigned int observed_sleep(unsigned int);
+#define sleep observed_sleep
+#include "../../tar/storage/storage_transaction.c"
+#undef sleep
+
+static int mode, closes, requests, spins, sleeps, errors;
+static int dummy;
+static void * operation_cookie;
+
+static unsigned int
+observed_sleep(unsigned int seconds)
+{
+	assert(seconds == 1 && ++sleeps <= 2);
+	return (0);
+}
+
+NETPACKET_CONNECTION *
+netpacket_open(const char * agent)
+{
+	assert(agent != NULL);
+	return (mode == 1 ? NULL : (NETPACKET_CONNECTION *)&dummy);
+}
+
+int
+netpacket_close(NETPACKET_CONNECTION * npc)
+{
+	assert(npc == (NETPACKET_CONNECTION *)&dummy);
+	closes++;
+	return (mode == 4 || mode == 8 ? -1 : 0);
+}
+
+int
+netpacket_op(NETPACKET_CONNECTION * npc, sendpacket_callback * send,
+    void * cookie)
+{
+	int rc;
+
+	assert(npc == (NETPACKET_CONNECTION *)&dummy);
+	assert(operation_cookie == NULL);
+	requests++;
+	if (mode == 2)
+		return (-1);
+	operation_cookie = cookie;
+	rc = send(cookie, npc);
+	operation_cookie = NULL;
+	return (rc);
+}
+
+int
+network_spin(int * done)
+{
+	assert(*done == 1);
+	spins++;
+	return (mode == 3 ? -1 : 0);
+}
+
+int
+netpacket_transaction_trycommit(NETPACKET_CONNECTION * npc,
+    uint64_t machine, uint8_t key, const uint8_t seqnum[32],
+    handlepacket_callback * callback)
+{
+	uint8_t packet[33] = {0};
+
+	assert(machine == 17 && (key == 0 || key == 1));
+	assert(seqnum[0] == 42 && seqnum[31] == 42);
+	if ((mode == 7 || mode == 8) && requests < 3)
+		packet[0] = 1;
+	if (mode == 5)
+		packet[0] = 2;
+	return (callback(operation_cookie, npc, NETWORK_STATUS_OK,
+	    NETPACKET_TRANSACTION_TRYCOMMIT_RESPONSE, packet, sizeof(packet)));
+}
+
+int
+netpacket_hmac_verify(uint8_t type, const uint8_t nonce[32],
+    const uint8_t * packet, size_t len, int key)
+{
+	assert(type == NETPACKET_TRANSACTION_TRYCOMMIT_RESPONSE);
+	assert(nonce[0] == 42 && packet != NULL && len == 1);
+	assert(key == CRYPTO_KEY_AUTH_PUT || key == CRYPTO_KEY_AUTH_DELETE);
+	/* Authenticated/invalid fixtures only; no cryptography is claimed. */
+	return (mode == 6 ? 1 : 0);
+}
+
+void
+netproto_printerr_internal(int status)
+{
+	(void)status;
+	errors++;
+}
+
+void
+libcperciva_warnx(const char * fmt, ...)
+{
+	(void)fmt;
+	abort();
+}
+
+int
+main(void)
+{
+	uint8_t seqnum[32];
+	int key, initial, modified, rc, confirmed;
+
+	memset(seqnum, 42, sizeof(seqnum));
+	for (key = 0; key <= 1; key++) {
+		for (initial = 0; initial <= 1; initial++) {
+			for (mode = 0; mode <= 8; mode++) {
+				closes = requests = spins = sleeps = errors = 0;
+				modified = initial;
+				rc = storage_transaction_commit(17, seqnum,
+				    (uint8_t)key, &modified);
+				assert(rc == (mode == 0 || mode == 7 ? 0 : -1));
+				confirmed = mode == 0 || mode == 4 ||
+				    mode == 7 || mode == 8;
+				assert(modified == (initial || confirmed));
+				assert(closes == (mode == 1 ? 0 : 1));
+				assert(sleeps == (mode == 7 || mode == 8 ? 2 : 0));
+				assert(errors == (mode == 5 || mode == 6 ? 1 : 0));
+			}
+		}
+	}
+	puts("PASS: 36 commit confirmation, failure and retry scenarios");
+	return (0);
+}

--- a/tests/unit/storage-commit.md
+++ b/tests/unit/storage-commit.md
@@ -1,0 +1,28 @@
+# Regression: commit modification reporting
+
+Supports PR848 at original head `7a7bee120e74d78ebadf5d13c49406684f8c7371`.
+
+From a configured Linux/GCC checkout run:
+
+```sh
+sh tests/unit/storage-commit.sh
+```
+
+An out-of-tree configured build directory may be passed as the first argument.
+This standalone regression is not automatically invoked by `make test`.
+
+Thirty-six scenarios execute the real commit loop and response callback: both
+key choices, initially clear/set modification flags, successful confirmation,
+close failure after confirmation, request/spin/open errors, invalid responses,
+and retry success/failure. Packets and authentication results are controlled
+fixtures. No real transaction, key, cryptographic validation or server is used.
+
+The original correction passes; common base
+`0bf0b299fed91139044c81cc6fcdc5521c34d235` fails the modification-flag assertion
+when closing after a simulated successful confirmation. Production source is
+unchanged by this follow-up.
+
+Prepared by ChatGPT ASTRA-TEN at the account owner's request. C retains the
+original report847, implementation and discovery credit. No new bounty claim.
+Review questions can be addressed in active follow-up sessions; no continuous
+autonomous monitoring is represented.

--- a/tests/unit/storage-commit.sh
+++ b/tests/unit/storage-commit.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+# Standalone GNU/POSIX regression. Configure first; no account is required.
+set -eu
+ulimit -c 0
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+build=${1:-"$root"}
+if [ ! -f "$build/config.h" ]; then
+    echo "Configure the project first, or pass a configured build directory." >&2
+    exit 2
+fi
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+set -- -I"$build"
+set -- "$@" -I"$root/lib"
+set -- "$@" -I"$root/lib-platform"
+set -- "$@" -I"$root/lib-platform/util"
+set -- "$@" -I"$root/lib/crypto"
+set -- "$@" -I"$root/lib/datastruct"
+set -- "$@" -I"$root/lib/keyfile"
+set -- "$@" -I"$root/lib/netpacket"
+set -- "$@" -I"$root/lib/netproto"
+set -- "$@" -I"$root/lib/network"
+set -- "$@" -I"$root/lib/util"
+set -- "$@" -I"$root/libarchive"
+set -- "$@" -I"$root/libcperciva/crypto"
+set -- "$@" -I"$root/libcperciva/datastruct"
+set -- "$@" -I"$root/libcperciva/util"
+set -- "$@" -I"$root/tar"
+set -- "$@" -I"$root/tar/ccache"
+set -- "$@" -I"$root/tar/chunks"
+set -- "$@" -I"$root/tar/multitape"
+set -- "$@" -I"$root/tar/storage"
+${CC:-cc} -DHAVE_CONFIG_H -DUSERAGENT='"unit-regression"' \
+    -std=c99 -O2 -Wall -Wextra -Werror -ffunction-sections -fdata-sections \
+    "$@" "$root/tests/unit/storage-commit.c" \
+    -Wl,--gc-sections -o "$tmp/storage-commit"
+"$tmp/storage-commit"


### PR DESCRIPTION
Fixes #847.

`storage_transaction_commit()` set `*storage_modified = 1` after `netpacket_close()`, but the commit loop only exits when the server has returned status 0 — an HMAC-verified confirmation that the commit happened. A close failure after that point returned `-1` with the flag still clear.

That flag is read in exactly one place, `tar/bsdtar.c:1331`, and only on a failed run: it upgrades the exit status to 2 and prints "Data on server was modified, but it might not be exactly what you requested". Losing it means a run that did change the server exits 1 and prints only "Error exit delayed from previous errors."

Setting the flag as soon as the server confirms fixes that. It can only move the flag from 0 to 1 in a case where the commit demonstrably occurred, so no run that committed nothing can now report "modified". The `err1` paths are unaffected — they are reachable only before a status-0 response.

## What I did not exercise

I did not build or run tarsnap, and did not induce a `netpacket_close()` failure, so I have not observed the wrong exit status; the reasoning is from the sources quoted in the issue. I did not survey out-of-tree consumers of this function.
