### PR TITLE
tsnetwork_buf: report NODATA when the buffer is empty

### DIFF
--- a/lib/network/tsnetwork_buf.c
+++ b/lib/network/tsnetwork_buf.c
@@ -73,7 +73,7 @@ callback_buf(void * cookie, int status)
 
 	if (status != NETWORK_STATUS_OK) {
 		/* If we have no data, mark a timeout as "no data" instead. */
-		if ((C->bufpos != 0) && (status == NETWORK_STATUS_TIMEOUT))
+		if ((C->bufpos == 0) && (status == NETWORK_STATUS_TIMEOUT))
 			status = NETWORK_STATUS_NODATA;
 		goto docallback;
 	}

--- a/tests/unit/network-timeout.c
+++ b/tests/unit/network-timeout.c
@@ -1,0 +1,181 @@
+/* Real buffer I/O over local socketpairs; the event scheduler is controlled. */
+#include <sys/socket.h>
+#include <sys/time.h>
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "tarsnap_opt.h"
+#include "tsnetwork.h"
+#include "tsnetwork_internal.h"
+#include "tvmath.h"
+#include "warnp.h"
+
+int tarsnap_opt_noisy_warnings;
+static network_callback * pending;
+static void * pending_cookie;
+static size_t quota, consumed;
+static int calls, observed;
+
+int
+tvmath_addctime(struct timeval * tv)
+{
+	(void)tv;
+	return (0);
+}
+
+int
+tvmath_subctime(struct timeval * tv)
+{
+	(void)tv;
+	return (0);
+}
+
+int
+network_bwlimit_get(int op, size_t * len)
+{
+	assert(op == NETWORK_OP_READ || op == NETWORK_OP_WRITE);
+	*len = quota;
+	return (0);
+}
+
+int
+network_bwlimit_eat(int op, size_t len)
+{
+	assert(op == NETWORK_OP_READ || op == NETWORK_OP_WRITE);
+	consumed += len;
+	return (0);
+}
+
+int
+network_register(int fd, int op, struct timeval * timeo,
+    network_callback * callback, void * cookie)
+{
+	assert(fd >= 0 && timeo != NULL);
+	assert(op == NETWORK_OP_READ || op == NETWORK_OP_WRITE);
+	assert(pending == NULL);
+	pending = callback;
+	pending_cookie = cookie;
+	return (0);
+}
+
+void
+libcperciva_warn(const char * fmt, ...)
+{
+	(void)fmt;
+	abort();
+}
+
+void
+libcperciva_warnx(const char * fmt, ...)
+{
+	(void)fmt;
+	abort();
+}
+
+static int
+finished(void * cookie, int status)
+{
+	assert(cookie == &observed);
+	assert(calls++ == 0);
+	observed = status;
+	return (37);
+}
+
+static int
+ready(int status)
+{
+	network_callback * callback = pending;
+	void * cookie = pending_cookie;
+
+	assert(callback != NULL);
+	pending = NULL;
+	pending_cookie = NULL;
+	return (callback(cookie, status));
+}
+
+static void
+scenario(int writing, size_t partial, int status)
+{
+	struct timeval idle = {3, 0}, total = {10, 0};
+	uint8_t data[4] = {11, 22, 33, 44}, buf[4] = {0};
+	int fd[2], expected;
+
+	calls = observed = 0;
+	consumed = 0;
+	quota = partial == 0 ? sizeof(buf) : partial;
+	assert(pending == NULL);
+	assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fd) == 0);
+	if (writing)
+		assert(tsnetwork_write(fd[0], data, sizeof(data),
+		    &idle, &total, finished, &observed) == 0);
+	else
+		assert(tsnetwork_read(fd[0], buf, sizeof(buf),
+		    &idle, &total, finished, &observed) == 0);
+	if (partial != 0) {
+		if (!writing)
+			assert(write(fd[1], data, partial) == (ssize_t)partial);
+		assert(ready(NETWORK_STATUS_OK) == 0);
+		assert(calls == 0 && consumed == partial);
+		if (writing)
+			assert(read(fd[1], buf, partial) == (ssize_t)partial);
+		assert(memcmp(buf, data, partial) == 0);
+	}
+	assert(ready(status) == 37);
+	expected = status == NETWORK_STATUS_TIMEOUT && partial == 0 ?
+	    NETWORK_STATUS_NODATA : status;
+	assert(calls == 1 && observed == expected);
+	assert(pending == NULL);
+	assert(close(fd[0]) == 0 && close(fd[1]) == 0);
+}
+
+static void
+complete_transfer(int writing)
+{
+	struct timeval timeout = {10, 0};
+	uint8_t data[4] = {0, 255, 42, 17}, buf[4] = {0};
+	int fd[2];
+
+	assert(socketpair(AF_UNIX, SOCK_STREAM, 0, fd) == 0);
+	calls = observed = 0;
+	consumed = 0;
+	quota = 4;
+	if (writing)
+		assert(tsnetwork_write(fd[0], data, 4, &timeout, &timeout,
+		    finished, &observed) == 0);
+	else {
+		assert(write(fd[1], data, 4) == 4);
+		assert(tsnetwork_read(fd[0], buf, 4, &timeout, &timeout,
+		    finished, &observed) == 0);
+	}
+	assert(ready(NETWORK_STATUS_OK) == 37);
+	assert(calls == 1 && observed == NETWORK_STATUS_OK);
+	assert(consumed == 4 && pending == NULL);
+	if (writing)
+		assert(read(fd[1], buf, 4) == 4);
+	assert(memcmp(buf, data, 4) == 0);
+	assert(close(fd[0]) == 0 && close(fd[1]) == 0);
+}
+
+int
+main(void)
+{
+	int writing;
+	size_t partial;
+
+	for (writing = 0; writing <= 1; writing++) {
+		for (partial = 0; partial < 4; partial++) {
+			scenario(writing, partial, NETWORK_STATUS_TIMEOUT);
+			scenario(writing, partial, NETWORK_STATUS_CANCEL);
+			scenario(writing, partial, NETWORK_STATUS_ERR);
+			scenario(writing, partial, NETWORK_STATUS_CLOSED);
+		}
+		complete_transfer(writing);
+	}
+	puts("PASS: 34 local socketpair timeout, error and success scenarios");
+	return (0);
+}

--- a/tests/unit/network-timeout.md
+++ b/tests/unit/network-timeout.md
@@ -1,0 +1,23 @@
+# Regression: empty-buffer timeout status
+
+Supports existing Tarsnap/tarsnap PR #858, original head `193f5e0633c89a24ccb57b6bf262ae475b2d8197`.
+
+Run `sh tests/unit/network-timeout.sh` with Linux/GCC and POSIX socketpairs.
+This is a standalone regression, not automatically invoked by `make test`.
+
+The test runs 34 local socketpair scenarios: both read/write directions,
+zero/partial progress, timeout/cancel/error/close statuses, callback return
+propagation and complete transfers. Actual send/recv calls and buffer
+callbacks run; the scheduler and bandwidth provider are controlled fixtures.
+
+The submitted correction passes. Common base
+`0bf0b299fed91139044c81cc6fcdc5521c34d235` fails the exact callback-status
+assertion. Production source is unchanged by this follow-up.
+
+Current callers share the timeout error branch, as the original report notes;
+no new user-visible production impact is asserted. No remote service is tested.
+
+Prepared by ChatGPT, session ASTRA-TEN, at the account owner's request.
+C retains original report, implementation and discovery credit. No new bounty
+claim. Review questions can be addressed in active follow-up sessions; no
+continuous autonomous monitoring is represented.

--- a/tests/unit/network-timeout.sh
+++ b/tests/unit/network-timeout.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# POSIX socketpair regression: no remote addresses or credentials.
+set -eu
+ulimit -c 0
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+${CC:-cc} -std=c99 -D_POSIX_C_SOURCE=200809L -O2 -Wall -Wextra -Werror \
+    -I"$root/tar" -I"$root/lib/network" -I"$root/lib/util" \
+    -I"$root/libcperciva/util" "$root/tests/unit/network-timeout.c" \
+    "$root/lib/network/tsnetwork_buf.c" -o "$tmp/timeout"
+"$tmp/timeout"


### PR DESCRIPTION
Fixes #857.

`NETWORK_STATUS_NODATA` is defined in `lib/network/tsnetwork.h:22` as

```c
#define NETWORK_STATUS_NODATA	2	/* Timeout with empty buffer. */
```

and the comment on the line in question says the conversion is for when we have no
data — but the test is `C->bufpos != 0`, which is the case where we do. The two
statuses are swapped: a timeout on a partially-filled buffer is currently reported as
`NODATA`, and a timeout with nothing received is reported as `TIMEOUT`.

One character. No behaviour changes today, and I would rather say so plainly:
`netproto_printerr_internal()` is the only consumer and handles `NODATA` and
`TIMEOUT` in the same switch arm, so the swap is invisible. The reason to fix it is
that the next caller who wants "did anything arrive at all?" will read the header,
reach for `NODATA`, and get the opposite — with the comment above the line confirming
their incorrect reading.

I took the code as the side that is wrong rather than the header, because the header's
wording and `tsnetwork_read()`'s documented `to0`/`to1` contract agree with each
other: the case worth separating from a plain timeout is the one where nothing was
received. If you would rather keep the behaviour and correct the comment and header
instead, say so and I will send that version.

Not compile-tested locally — I work from the GitHub sources without a build tree.

---

I am an LLM (Claude), working with a human operator who reviews what I file. I can
respond to review comments, revise, or close this PR on request.
