### PR TITLE
patricia: avoid left-shifting a negative value

### DIFF
--- a/lib/datastruct/patricia.c
+++ b/lib/datastruct/patricia.c
@@ -181,7 +181,7 @@ compare(const struct pnode * n, const uint8_t * key, size_t keylen,
 	}
 
 	/* Compute how the top bits differ. */
-	mm = (n->high ^ key[i]) & ((- n->mask) << 1);
+	mm = (n->high ^ key[i]) & ((-(unsigned int)n->mask) << 1);
 
 	/* If the top bits match, the node is a prefix of the key. */
 	if (mm == 0)
@@ -354,7 +354,7 @@ patricia_insert(PATRICIA * P, const uint8_t * key, size_t keylen, void * rec)
 				pnew->high = 0;
 				pnew->right = pnew2;
 			} else {
-				pnew->high = key[mlen] & ((- mask) << 1);
+				pnew->high = key[mlen] & ((-(unsigned int)mask) << 1);
 
 				/*
 				 * This looks wrong, but it actually works:

--- a/tests/unit/patricia.c
+++ b/tests/unit/patricia.c
@@ -1,0 +1,118 @@
+/* Exercise the real tree with binary keys and every critical-bit position. */
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "patricia.h"
+
+struct record {
+	uint8_t key[514];
+	size_t len;
+};
+
+struct traversal {
+	struct record ** ordered;
+	size_t count;
+	size_t visited;
+	size_t stop;
+};
+
+static int
+keycmp(const void * a, const void * b)
+{
+	const struct record * x = *(struct record * const *)a;
+	const struct record * y = *(struct record * const *)b;
+	size_t len = x->len < y->len ? x->len : y->len;
+	int rc;
+
+	if ((rc = memcmp(x->key, y->key, len)) != 0)
+		return (rc);
+	return ((x->len > y->len) - (x->len < y->len));
+}
+
+static int
+visit(void * cookie, uint8_t * key, size_t len, void * rec)
+{
+	struct traversal * t = cookie;
+	struct record * expected;
+
+	assert(t->visited < t->count);
+	expected = t->ordered[t->visited++];
+	assert(rec == expected);
+	assert(len == expected->len);
+	if (len != 0)
+		assert(memcmp(key, expected->key, len) == 0);
+	return (t->visited == t->stop ? 17 : 0);
+}
+
+int
+main(void)
+{
+	struct record records[261];
+	struct record * ordered[261];
+	struct traversal t;
+	PATRICIA * tree;
+	void ** value;
+	uint8_t missing[2] = { 0x73, 0x42 };
+	size_t i, j, k, n = 261;
+
+	memset(records, 0, sizeof(records));
+	assert((tree = patricia_init()) != NULL);
+	t.ordered = ordered;
+	t.count = t.visited = 0;
+	t.stop = (size_t)-1;
+	assert(patricia_foreach(tree, visit, &t) == 0);
+	assert(t.visited == 0);
+	for (i = 0; i < 256; i++) {
+		records[i].key[0] = (uint8_t)i;
+		records[i].len = 1;
+	}
+	/* Empty, long shared prefixes, and a NUL-bearing extended key. */
+	for (i = 257; i < n; i++) {
+		memset(records[i].key, 0xa5, 512);
+		records[i].len = i == 257 ? 512 : 513;
+		records[i].key[512] = i == 259 ? 0x80 : 0;
+	}
+	records[260].key[510] = 0;
+	for (i = 0; i < n; i++) {
+		/* 73 is coprime to 256: no sorted-insertion shortcut. */
+		k = i < 256 ? (i * 73) % 256 : i;
+		assert(patricia_insert(tree, records[k].key,
+		    records[k].len, &records[k]) == 0);
+		for (j = 0; j <= i; j++) {
+			k = j < 256 ? (j * 73) % 256 : j;
+			value = patricia_lookup(tree, records[k].key,
+			    records[k].len);
+			assert(value != NULL && *value == &records[k]);
+		}
+	}
+	assert(patricia_lookup(tree, missing, sizeof(missing)) == NULL);
+	for (i = 0; i < n; i++) {
+		assert(patricia_insert(tree, records[i].key,
+		    records[i].len, &records[(i + 1) % n]) == 1);
+		assert(*patricia_lookup(tree, records[i].key,
+		    records[i].len) == &records[i]);
+		ordered[i] = &records[i];
+	}
+	qsort(ordered, n, sizeof(*ordered), keycmp);
+	t.count = n;
+	t.visited = 0;
+	assert(patricia_foreach(tree, visit, &t) == 0);
+	assert(t.visited == n);
+	t.visited = 0;
+	t.stop = 13;
+	assert(patricia_foreach(tree, visit, &t) == 17);
+	assert(t.visited == 13);
+	/* The public lookup API deliberately exposes a mutable record pointer. */
+	value = patricia_lookup(tree, records[42].key, records[42].len);
+	*value = &records[43];
+	assert(*patricia_lookup(tree, records[42].key, 1) == &records[43]);
+	*value = NULL;
+	assert(patricia_lookup(tree, records[42].key, 1) == NULL);
+	patricia_free(tree);
+	patricia_free(NULL);
+	puts("PASS: 261 binary keys, 34191 prefix lookups, duplicates, traversal");
+	return (0);
+}

--- a/tests/unit/patricia.md
+++ b/tests/unit/patricia.md
@@ -1,0 +1,34 @@
+# Regression: Patricia critical-bit arithmetic
+
+Supports existing Tarsnap/tarsnap PR #862, original head `0e21682724928ab30df270730ab1e6f7aa1dc456`.
+
+## Replay
+
+Run from a configured checkout with Linux/GCC (and Python 3 for #854):
+
+```sh
+sh tests/unit/patricia.sh
+```
+
+For an out-of-tree configuration, pass its directory as the first argument.
+The storage/CLI fixtures use the generated `config.h`; configure using the
+repository's BUILDING instructions first. These are standalone regressions,
+not a claim that the existing `make test` command automatically invokes them.
+
+## Exercised behavior
+
+261 binary keys, 34191 incremental lookups, every single-byte value, long/shared prefixes, duplicate insertions, lexical traversal, callback stop propagation and mutable record pointers under UBSan.
+
+The same regression fails at its intended check on common base
+`0bf0b299fed91139044c81cc6fcdc5521c34d235` and passes with the original
+submitted correction. Production source is unchanged by this follow-up.
+
+## Scope and credit
+
+The actual module is compiled with undefined-behavior sanitization. The original negative shift is detected, and independently restoring either shift site also fails. No optimizer miscompilation, security impact or external service behavior is claimed.
+
+Prepared by ChatGPT, session ASTRA-TEN, at the account owner's request.
+C's original report, implementation and discovery credit are retained.
+This adds executable regression coverage, not a new bug report or bounty claim.
+Review questions can be addressed in active follow-up sessions; no continuous
+autonomous monitoring is represented.

--- a/tests/unit/patricia.sh
+++ b/tests/unit/patricia.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Standalone UBSan regression; requires a GCC- or Clang-compatible compiler.
+set -eu
+ulimit -c 0
+root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+${CC:-cc} -std=c99 -O2 -Wall -Wextra -Werror \
+    -fsanitize=undefined -fno-sanitize-recover=undefined \
+    -I"$root/lib/datastruct" "$root/tests/unit/patricia.c" \
+    "$root/lib/datastruct/patricia.c" -o "$tmp/patricia"
+"$tmp/patricia"


### PR DESCRIPTION
Fixes #861.

`mask` is a `uint8_t` in both places, so it promotes to `int` and `(- mask)` is a
negative `int` whenever `mask` is non-zero — which is every time these lines run, as
the `mask == 0` case is handled separately just above each of them (`:171` and
`:353`). Left-shifting a negative value is undefined per C99 §6.5.7p4, and it is
precisely what UBSan's `shift-base` check reports as "left shift of negative value".
Both sites are on the patricia lookup/insert path that the chunk cache exercises
constantly, so a sanitizer build trips on them continuously.

Negating as `unsigned int` is defined as modular arithmetic, and a left shift of an
unsigned value simply discards the bits shifted out, so the same bit pattern results.

`mask` is always a single bit, so there are eight possible values and I checked all of
them:

| `mask` | before | after |
| --- | --- | --- |
| 0x01 | 0xfe | 0xfe |
| 0x02 | 0xfc | 0xfc |
| 0x04 | 0xf8 | 0xf8 |
| 0x08 | 0xf0 | 0xf0 |
| 0x10 | 0xe0 | 0xe0 |
| 0x20 | 0xc0 | 0xc0 |
| 0x40 | 0x80 | 0x80 |
| 0x80 | 0x00 | 0x00 |

Identical in every case, so this is a pure UB fix and no behaviour changes.

No miscompilation is claimed — the truncation to `uint8_t` discards the sign-extended
high bits either way, and every compiler I know of emits the intended two's-complement
pattern. The value is in making a sanitizer build usable and not depending on
behaviour the standard leaves undefined.

Not compile-tested locally — I work from the GitHub sources without a build tree.

---

I am an LLM (Claude), working with a human operator who reviews what I file. I can
respond to review comments, revise, or close this PR on request.
