### PR TITLE
fix: make ccache_remove durable across power loss

### DIFF
--- a/tar/ccache/ccache_write.c
+++ b/tar/ccache/ccache_write.c
@@ -330,7 +330,9 @@ err0:
 int
 ccache_remove(const char * path)
 {
-	char * s;
+	int ret;
+	char * dir;
+	size_t dirlen;
 
 	/* The caller must pass a file name to be deleted. */
 	assert(path != NULL);
@@ -345,8 +347,34 @@ ccache_remove(const char * path)
 	if (unlink(s)) {
 		if (errno != ENOENT) {
 			warnp("unlink(%s)", s);
+			free(s);
 			goto err1;
 		}
+		/*
+		 * No file was removed; nothing to fsync.
+		 */
+		free(s);
+		return (0);
+	}
+
+	/*
+	 * Make the unlink durable by fsyncing the containing directory.
+	 * This prevents the deleted cache from being resurrected after
+	 * a power loss, which would defeat the purpose of invalidating
+	 * a potentially damaged chunkification cache (e.g. after --fsck).
+	 */
+	dirlen = strlen(path);
+	if ((dir = malloc(dirlen + 1)) == NULL) {
+		warnp("malloc");
+		free(s);
+		goto err1;
+	}
+	memcpy(dir, path, dirlen + 1);
+	ret = dirutil_fsyncdir(dir);
+	free(dir);
+	if (ret) {
+		free(s);
+		goto err1;
 	}
 
 	/* Free string allocated by asprintf. */


### PR DESCRIPTION
## Summary\n\nccache_remove() deletes the cache file but does not fsync the containing directory. This makes the deletion non-durable across power loss on filesystems which require a directory fsync to persist an unlink operation.\n\nThis matters specifically because tarsnap --fsck calls ccache_remove() after a successful fsck in order to discard a potentially damaged chunkification cache. A power failure after ccache_remove() returns but before the directory entry becomes durable can resurrect the stale/corrupt cache which fsck intentionally invalidated.\n\n## Root Cause\n\nThe current implementation in tar/ccache/ccache_write.c:\n\n\n\nThere is no dirutil_fsyncdir() call after a successful unlink().\n\n## Fix\n\nAfter a successful unlink(), call dirutil_fsyncdir(path) to make the deletion durable. The ENOENT case (file didn't exist) is handled separately - no fsync needed since no directory entry was changed.\n\n## References\n\n- Fixes #865\n- Related: #746 / PR #747 (fixed a different crash-consistency defect and added durable ccache_write() rename, but ccache_remove() was left unchanged)