### PR TITLE
Reject NUL escapes in mtree pathnames

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -711,6 +711,7 @@ EXTRA_DIST+=								\
 	tests/07-selecting-files-nT-full.good				\
 	tests/07-selecting-files-nT-partial.good			\
 	tests/07-selecting-files.sh					\
+	tests/08-mtree-nul-pathname.sh				        \
 	tests/fake-passphrased.keys					\
 	tests/fake.keys							\
 	tests/shared_test_functions.sh					\

--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -105,7 +105,7 @@ static int	cleanup(struct archive_read *);
 static int	mtree_bid(struct archive_read *);
 static int	parse_file(struct archive_read *, struct archive_entry *,
 		    struct mtree *, struct mtree_entry *, int *);
-static void	parse_escapes(char *, struct mtree_entry *);
+static int	parse_escapes(char *, struct mtree_entry *);
 static int	parse_line(struct archive_read *, struct archive_entry *,
 		    struct mtree *, struct mtree_entry *, int *);
 static int	parse_keyword(struct archive_read *, struct mtree *,
@@ -353,7 +353,11 @@ process_add_entry(struct archive_read *a, struct mtree *mtree,
 
 	memcpy(entry->name, line, len);
 	entry->name[len] = '\0';
-	parse_escapes(entry->name, entry);
+	if (parse_escapes(entry->name, entry)) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+		    "NUL in mtree pathname");
+		return (ARCHIVE_FATAL);
+	}
 
 	line += len;
 	for (iter = *global; iter != NULL; iter = iter->next) {
@@ -1031,7 +1035,7 @@ skip(struct archive_read *a)
  * Since parsing backslash sequences always makes strings shorter,
  * we can always do this conversion in-place.
  */
-static void
+static int
 parse_escapes(char *src, struct mtree_entry *mentry)
 {
 	char *dest = src;
@@ -1098,9 +1102,12 @@ parse_escapes(char *src, struct mtree_entry *mentry)
 				break;
 			}
 		}
+		if (c == '\0')
+			return (1);
 		*dest++ = c;
 	}
 	*dest = '\0';
+	return (0);
 }
 
 /*

--- a/tests/08-mtree-nul-pathname.sh
+++ b/tests/08-mtree-nul-pathname.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+### Constants
+c_valgrind_min=1
+leading_nul_mtree=${s_basename}-leading-nul.mtree
+embedded_nul_mtree=${s_basename}-embedded-nul.mtree
+valid_escape_mtree=${s_basename}-valid-escape.mtree
+leading_nul_output=${s_basename}-leading-nul.output
+embedded_nul_output=${s_basename}-embedded-nul.output
+valid_escape_output=${s_basename}-valid-escape.output
+
+scenario_cmd() {
+	# Case 1: Leading NUL
+	# Pathname '\0' must be rejected with a nonzero exit and diagnostic 'NUL in mtree pathname'.
+	# It must not create an archive entry.
+	printf '%s\n' '#mtree' '\0 type=file' > "${leading_nul_mtree}"
+	setup_check "reject mtree pathname with leading NUL"
+	${c_valgrind_cmd} ./tarsnap --no-default-config \
+		-c --dry-run "@${leading_nul_mtree}" \
+		> "${leading_nul_output}" 2>&1
+	expected_exitcode 1 $? > "${c_exitfile}"
+
+	setup_check "check leading NUL mtree diagnostic"
+	grep -q "NUL in mtree pathname" "${leading_nul_output}"
+	echo $? > "${c_exitfile}"
+
+	setup_check "check leading NUL mtree creates no entry"
+	! grep -q '^a ' "${leading_nul_output}"
+	echo $? > "${c_exitfile}"
+
+	# Case 2: Embedded NUL
+	# 'alpha\0one' and 'alpha\0two' must both be rejected with the same diagnostic
+	# and must not be silently truncated to 'alpha'.
+	printf '%s\n' '#mtree' 'alpha\0one type=file' 'alpha\0two type=file' > \
+		"${embedded_nul_mtree}"
+	setup_check "reject mtree pathname with embedded NUL"
+	${c_valgrind_cmd} ./tarsnap --no-default-config \
+		-c -v --dry-run "@${embedded_nul_mtree}" \
+		> "${embedded_nul_output}" 2>&1
+	expected_exitcode 1 $? > "${c_exitfile}"
+
+	setup_check "check embedded NUL mtree diagnostic"
+	grep -q "NUL in mtree pathname" "${embedded_nul_output}"
+	echo $? > "${c_exitfile}"
+
+	setup_check "check embedded NUL mtree creates no truncated entry"
+	! grep -q '^a alpha$' "${embedded_nul_output}"
+	echo $? > "${c_exitfile}"
+
+	# Case 3: Valid non-NUL escape
+	# 'valid\040name' must still be accepted and produce the pathname 'valid name'.
+	printf '%s\n' '#mtree' 'valid\040name type=file' > "${valid_escape_mtree}"
+	setup_check "accept mtree pathname with non-NUL escape"
+	${c_valgrind_cmd} ./tarsnap --no-default-config \
+		-c -v --dry-run "@${valid_escape_mtree}" \
+		> "${valid_escape_output}" 2>&1
+	echo $? > "${c_exitfile}"
+
+	setup_check "check non-NUL mtree pathname escape output"
+	grep -q '^a valid name$' "${valid_escape_output}"
+	echo $? > "${c_exitfile}"
+}


### PR DESCRIPTION
## Summary

Fixes a crash when an mtree pathname escape decodes to NUL.

`parse_escapes()` previously wrote a decoded NUL directly into the
pathname buffer. Since the pathname is subsequently treated as a
C string, this could produce an empty/truncated pathname and eventually
cause a NULL dereference in the PAX writer.

This change:

- Detects decoded NUL characters while parsing mtree pathname escapes.
- Rejects the malformed pathname with `ARCHIVE_FATAL`.
- Reports `NUL in mtree pathname`.
- Prevents embedded NULs from silently truncating pathnames.
- Adds regression coverage for leading NUL, embedded NUL, and a valid
  `\040` escape.

## Testing

- `./tests/08-mtree-nul-pathname.sh`
- `make check`