### PR TITLE
fix: resolve #855 ([Bug bounty] network_writeq_cancel() spins forever)

### DIFF
--- a/lib/network/tsnetwork_writeq.c
+++ b/lib/network/tsnetwork_writeq.c
@@ -210,7 +210,7 @@ err0:
  * no way to know how much data from the currently in-progress write was
  * written) this should probably only be used prior to closing a connection.
  * The callbacks for each pending write will be called with a status of
- * NETWORK_STATUS_DEQUEUE, and network_writeq_cancel will return the first
+ * NETWORK_STATUS_CANCEL, and network_writeq_cancel will return the first
  * non-zero value returned by a callback.
  */
 int
@@ -221,6 +221,17 @@ network_writeq_cancel(NETWORK_WRITEQ * Q)
 	/* Keep on deregistering callbacks until the queue is empty. */
 	while (Q->head != NULL) {
 		rc2 = network_deregister(Q->fd, NETWORK_OP_WRITE);
+		if (rc2 == 0) {
+			/* No callback was registered; manually dequeue. */
+			struct network_writeq_buf *head_old = Q->head;
+			Q->head = head_old->next;
+			if (Q->tailptr == &head_old->next)
+				Q->tailptr = &Q->head;
+			if (head_old->callback)
+				rc2 = head_old->callback(head_old->cookie,
+				    NETWORK_STATUS_CANCEL);
+			free(head_old);
+		}
 		rc = rc ? rc : rc2;
 	}
 


### PR DESCRIPTION
Fixes #855

### Autonomously Resolved by MEA
This PR addresses issue #855: `[Bug bounty] network_writeq_cancel() spins forever when a queued write was never registered`.

**File modified:** `lib/network/tsnetwork_writeq.c`

---
*Generated and verified by MEA Sovereign Agent.*