### PR TITLE
mtree: check for NULL strchr return in option parsing

### DIFF
--- a/libarchive/archive_read_support_format_mtree.c
+++ b/libarchive/archive_read_support_format_mtree.c
@@ -272,7 +272,7 @@ process_global_set(struct archive_read *a,
 		line = next;
 		next = line + strcspn(line, " \t\r\n");
 		eq = strchr(line, '=');
-		if (eq > next)
+		if (eq == NULL || eq > next)
 			len = next - line;
 		else
 			len = eq - line;
@@ -370,7 +370,7 @@ process_add_entry(struct archive_read *a, struct mtree *mtree,
 		line = next;
 		next = line + strcspn(line, " \t\r\n");
 		eq = strchr(line, '=');
-		if (eq > next)
+		if (eq == NULL || eq > next)
 			len = next - line;
 		else
 			len = eq - line;


### PR DESCRIPTION
Fixes #885

### Problem

As reported in #885, when parsing mtree attributes in `process_global_set()` and `process_add_entry()`, `strchr(line, '=')` returns `NULL` for attributes without an `=` character (such as bare `w`).
The condition `if (eq > next)` evaluated to false when `eq` was `NULL`, falling through to `len = eq - line`. Because `eq` was `NULL`, this produced an unsigned `size_t` underflow (~18446650248716499851) and caused an out-of-bounds read in `remove_option()`, crashing Tarsnap with `SIGSEGV` (exit code 139).

### Solution

Check `if (eq == NULL || eq > next)` before evaluating `len = eq - line`, matching upstream libarchive commit `7476f48f19fcea3441bed91abbc8a19756e24d90`.

Affected locations:
- `libarchive/archive_read_support_format_mtree.c:275` (`process_global_set`)
- `libarchive/archive_read_support_format_mtree.c:373` (`process_add_entry`)

### Verification

Verified with the 15-byte reproduction case from #885 (`236d747265650a662320772077000a`). Bare attributes are safely bounded to `next - line` without underflowing length or reading past allocation boundaries.

### Agent Disclosure

This pull request was prepared by an AI assistant operating with the repository owner's authorization. The contributor is available to discuss any requested code changes or revisions.
