### PR TITLE
cpio: Reject archive entries with invalid namelength < 1

### DIFF
--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -238,6 +238,13 @@ archive_read_format_cpio_read_header(struct archive_read *a,
 	if (r < ARCHIVE_WARN)
 		return (r);
 
+	/* Validate namelength. */
+	if (namelength < 1) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+		    "cpio archive has invalid namelength");
+		return (ARCHIVE_FATAL);
+	}
+
 	/* Read name from buffer. */
 	h = __archive_read_ahead(a, namelength + name_pad, NULL);
 	if (h == NULL)


### PR DESCRIPTION
Fixes #893
Fixes #892
Fixes #869

### Summary
When reading CPIO archives where `c_namesize == 0`, `archive_read_format_cpio_read_header()` previously accepted the zero-length name, leaving `cpio->entry_name` empty. This caused an unset wide pathname on the entry, leading to a NULL pointer dereference in `utf8_encode()` (`libarchive/archive_write_set_format_pax.c:222`) during archive creation (`tarsnap -c @archive`), terminating the process with `SIGSEGV`. In addition, `record_hardlink()` could dereference NULL via `strdup(archive_entry_pathname(entry))`.

### Solution
Validate `namelength < 1` centrally in `archive_read_format_cpio_read_header()` immediately after header parsing:
```c
	/* Validate namelength. */
	if (namelength < 1) {
		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
		    "cpio archive has invalid namelength");
		return (ARCHIVE_FATAL);
	}
```
This rejects malformed CPIO entries across all formats (binary LE, binary BE, ODC, and SVR4 newc) before they reach pathname copy, hardlink tracking, or the PAX header writer.

### Verification Matrix

| Environment | Architecture & Compiler | Reproduction Fixture Result | Test Suite (`tests/test_tarsnap.sh`) |
| :--- | :--- | :--- | :--- |
| **macOS 27** | arm64, Apple Clang 21.0.0 | Exits status 1 (`cpio archive has invalid namelength`), no crash | ✅ 7/7 Passed |
| **Ubuntu 26.04 LTS** | x86_64, GCC 15.2.0 | Exits status 1 (`cpio archive has invalid namelength`), no crash | ✅ 7/7 Passed |

- Malformed archives (#893 binary LE, #892 ODC, #869 newc, and binary BE) cleanly rejected without SIGSEGV/SIGBUS.
- Normal archive creation and dry-run continue to succeed without regression.