### PR TITLE
ar: reject long filename offset at or beyond string table end

### DIFF
--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -322,7 +322,7 @@ archive_read_format_ar_read_header(struct archive_read *a,
 		 * If we can't look up the real name, warn and return
 		 * the entry with the wrong name.
 		 */
-		if (ar->strtab == NULL || number > ar->strtab_size) {
+		if (ar->strtab == NULL || number >= ar->strtab_size) {
 			archive_set_error(&a->archive, EINVAL,
 			    "Can't find long filename for entry");
 			archive_entry_copy_pathname(entry, filename);


### PR DESCRIPTION
Fixes #903

### Problem

In GNU/SVR4 AR archives, member long filenames are referenced via `/<number>`, where `<number>` is a base-10 byte offset into the filename string table (`//`).

In `libarchive/archive_read_support_format_ar.c:archive_read_format_ar_read_header()`, the offset validation check was:

```c
if (ar->strtab == NULL || number > ar->strtab_size) {
    ...
}
archive_entry_copy_pathname(entry, &ar->strtab[(size_t)number]);
```

Because valid byte offsets into `ar->strtab` span `0` through `ar->strtab_size - 1`, the condition `number > ar->strtab_size` permits `number == ar->strtab_size`. When this occurs, `&ar->strtab[(size_t)number]` points one byte beyond the allocated string table buffer. 

`archive_entry_copy_pathname()` subsequently invokes `strlen()` on that out-of-bounds pointer, causing:
- An AddressSanitizer `heap-buffer-overflow` / heap-buffer-over-read.
- An immediate `SIGSEGV` (exit status 11 / 139) on standard builds.

### Solution

Change the validation check to:

```c
if (ar->strtab == NULL || number >= ar->strtab_size) {
```

When `number >= ar->strtab_size`:
1. An `EINVAL` error is recorded: `"Can't find long filename for entry"`.
2. The raw fallback filename is preserved via `archive_entry_copy_pathname(entry, filename)`.
3. Common header fields are parsed and `ARCHIVE_WARN` is returned.

This safely rejects off-by-one and out-of-bounds offsets and matches upstream libarchive's canonical implementation.

### Verification

Tested against the 130-byte reproduction archive from #903:
- With `number >= ar->strtab_size`, the parser safely falls back to `filename` and emits a warning rather than dereferencing one byte past `ar->strtab`.
- Valid in-bounds GNU filename references continue to resolve correctly.

### Agent Disclosure

This pull request was prepared by an AI assistant operating with the repository contributor's authorization. The contributor is actively monitoring this PR and available to discuss feedback or revisions.
