### PR TITLE
compress: reject invalid maxcode_bits and reserved bits in .Z header

### DIFF
--- a/libarchive/archive_read_support_compression_compress.c
+++ b/libarchive/archive_read_support_compression_compress.c
@@ -174,7 +174,8 @@ compress_bidder_bid(struct archive_read_filter_bidder *self,
 
 	(void)self; /* UNUSED */
 
-	buffer = __archive_read_filter_ahead(filter, 2, &avail);
+	/* Shortest valid compress file is 3 bytes. */
+	buffer = __archive_read_filter_ahead(filter, 3, &avail);
 
 	if (buffer == NULL)
 		return (0);
@@ -188,9 +189,14 @@ compress_bidder_bid(struct archive_read_filter_bidder *self,
 		return (0);
 	bits_checked += 8;
 
-	/*
-	 * TODO: Verify more.
-	 */
+	/* Third byte holds compression parameters. Reserved bits must be zero. */
+	if (buffer[2] & 0x20 || buffer[2] & 0x40)
+		return (0);
+
+	/* Maximum code size must be between 9 and 16 bits. */
+	if ((buffer[2] & 0x1f) < 9 || (buffer[2] & 0x1f) > 16)
+		return (0);
+	bits_checked += 8;
 
 	return (bits_checked);
 }
@@ -233,6 +239,15 @@ compress_bidder_init(struct archive_read_filter *self)
 	(void)getbits(self, 8); /* Skip second signature byte. */
 
 	code = getbits(self, 8);
+	if (code < 0 || (code & 0x1f) < 9 || (code & 0x1f) > 16 ||
+	    (code & 0x20) != 0 || (code & 0x40) != 0) {
+		free(out_block);
+		free(state);
+		self->data = NULL;
+		archive_set_error(&self->archive->archive, -1,
+		    "Invalid compressed data");
+		return (ARCHIVE_FATAL);
+	}
 	state->maxcode_bits = code & 0x1f;
 	state->maxcode = (1 << state->maxcode_bits);
 	state->use_reset_code = code & 0x80;
@@ -417,6 +432,9 @@ getbits(struct archive_read_filter *self, int n)
 		0x00, 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff,
 		0x1ff, 0x3ff, 0x7ff, 0xfff, 0x1fff, 0x3fff, 0x7fff, 0xffff
 	};
+
+	if (n < 0 || n > 16)
+		return (ARCHIVE_FATAL);
 
 	while (state->bits_avail < n) {
 		if (state->avail_in <= 0) {


### PR DESCRIPTION
Fixes #914

## Problem

In `libarchive/archive_read_support_compression_compress.c`, the Unix compress (`.Z`) decoder accepts a parameter byte declaring an invalid maximum code size (> 16 bits or < 9 bits) or set reserved bits.

When an input specifies `maxbits = 17` (e.g. parameter byte `0x11`), `state->maxcode_bits` is set to 17. As decompression progresses and the dictionary grows, `state->bits` reaches 17. When `getbits(self, 17)` is called, it executes:
```c
return (code & mask[n]);
```
where `mask` is a static array defined with only 17 elements (indices 0 through 16):
```c
static const int mask[] = {
    0x00, 0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f, 0xff,
    0x1ff, 0x3ff, 0x7ff, 0xfff, 0x1fff, 0x3fff, 0x7fff, 0xffff
};
```
Accessing `mask[17]` reads out-of-bounds, triggering AddressSanitizer `global-buffer-overflow` / `SIGSEGV` and terminating Tarsnap.

## Solution

1. **Bidder Validation (`compress_bidder_bid`)**:
   - Inspect at least 3 bytes (`__archive_read_filter_ahead(filter, 3, &avail)`).
   - Validate that reserved bits 5 and 6 are zero (`buffer[2] & 0x20 || buffer[2] & 0x40`).
   - Validate that the maximum code size is between 9 and 16 bits (`(buffer[2] & 0x1f) < 9 || (buffer[2] & 0x1f) > 16`).
   - Reject the bid (return 0) if any format constraints are violated.

2. **Decompressor Initialization Validation (`compress_bidder_init`)**:
   - When reading the parameter byte, verify that `code >= 0`, `9 <= (code & 0x1f) <= 16`, and reserved bits are 0.
   - On error, cleanly free allocated `out_block` and `state` buffers (preventing memory leaks), emit `"Invalid compressed data"`, and return `ARCHIVE_FATAL`.

3. **Defense-in-Depth in `getbits`**:
   - Added `if (n < 0 || n > 16) return (ARCHIVE_FATAL);` at the beginning of `getbits()` to guarantee that `mask[n]` can never be accessed out of bounds under any circumstance.

## Reference
Upstream libarchive commit `f0b1dbbc325a2d922015eee402b72edd422cb9ea` (Issue 547).