### PR TITLE
iso9660: validate directory record bounds within logical block

### DIFF
--- a/libarchive/archive_read_support_format_iso9660.c
+++ b/libarchive/archive_read_support_format_iso9660.c
@@ -603,6 +603,7 @@ archive_read_format_iso9660_read_header(struct archive_read *a,
 		while (iso9660->entry_bytes_remaining > 0) {
 			const void *block;
 			const unsigned char *p;
+			const unsigned char *block_end;
 			ssize_t step = iso9660->logical_block_size;
 			if (step > iso9660->entry_bytes_remaining)
 				step = iso9660->entry_bytes_remaining;
@@ -616,10 +617,18 @@ archive_read_format_iso9660_read_header(struct archive_read *a,
 			__archive_read_consume(a, step);
 			iso9660->current_position += step;
 			iso9660->entry_bytes_remaining -= step;
+			block_end = (const unsigned char *)block + step;
 			for (p = (const unsigned char *)block;
-			     *p != 0 && p < (const unsigned char *)block + step;
+			     p < block_end && *p != 0;
 			     p += *p) {
 				struct file_info *child;
+
+				/*
+				 * Directory records cannot cross sector boundaries
+				 * and must be at least 34 bytes to contain the name fields.
+				 */
+				if (*p < 34 || *p > (size_t)(block_end - p))
+					break;
 
 				/* N.B.: these special directory identifiers
 				 * are 8 bit "values" even on a 
@@ -635,12 +644,14 @@ archive_read_format_iso9660_read_header(struct archive_read *a,
 				    && *(p + DR_name_offset) == '\001')
 					continue;
 				child = parse_file_info(iso9660, file, p);
-				add_entry(iso9660, child);
-				if (iso9660->seenRockridge) {
-					a->archive.archive_format =
-					    ARCHIVE_FORMAT_ISO9660_ROCKRIDGE;
-					a->archive.archive_format_name =
-					    "ISO9660 with Rockridge extensions";
+				if (child != NULL) {
+					add_entry(iso9660, child);
+					if (iso9660->seenRockridge) {
+						a->archive.archive_format =
+						    ARCHIVE_FORMAT_ISO9660_ROCKRIDGE;
+						a->archive.archive_format_name =
+						    "ISO9660 with Rockridge extensions";
+					}
 				}
 			}
 		}
@@ -723,7 +734,11 @@ parse_file_info(struct iso9660 *iso9660, struct file_info *parent,
 	const unsigned char *p;
 	int flags;
 
-	/* TODO: Sanity check that name_len doesn't exceed length, etc. */
+	if (isodirrec[DR_length_offset] < 34)
+		return (NULL);
+	name_len = (size_t)isodirrec[DR_name_len_offset];
+	if (DR_name_offset + name_len > isodirrec[DR_length_offset])
+		return (NULL);
 
 	/* Create a new file entry and copy data from the ISO dir record. */
 	file = (struct file_info *)malloc(sizeof(*file));


### PR DESCRIPTION
Fixes #907

## Problem

In `libarchive/archive_read_support_format_iso9660.c`, the directory scanning loop in `archive_read_format_iso9660_read_header()`:
```c
for (p = (const unsigned char *)block;
     *p != 0 && p < (const unsigned char *)block + step;
     p += *p) {
    /* Skip '.' entry. */
    if (*(p + DR_name_len_offset) == 1
        && *(p + DR_name_offset) == '')
        continue;
    /* Skip '..' entry. */
    if (*(p + DR_name_len_offset) == 1
        && *(p + DR_name_offset) == '')
        continue;
    child = parse_file_info(iso9660, file, p);
    add_entry(iso9660, child);
```

1. **Loop Condition Out-of-Bounds Evaluation**: `*p != 0` was evaluated before `p < block + step`. When `p` reached the end of the block buffer, evaluating `*p` was an out-of-bounds read past the buffer.
2. **Buffer Over-Read on Boundary Records**: When a non-zero length byte appeared at the tail of a 2,048-byte logical block (such as a `0x22` record length byte at offset 2,047), `p < block + step` was satisfied, so the loop entered the body with only 1 byte remaining in the block. Reading directory record fields at `p + DR_name_len_offset` (offset 32) and `p + DR_name_offset` (offset 33) read 31 and 32 bytes beyond the end of the heap-allocated block buffer, causing AddressSanitizer `heap-buffer-overflow`.
3. **Specification Violation**: Per ECMA-119 / ISO9660 §6.8.1 (*"A Directory Record shall not cross a Logical Sector boundary"*), a directory record cannot extend past the logical sector/block boundary, and a valid directory record requires at least 34 bytes (33 bytes fixed header + at least 1 byte identifier).

## Solution

1. **Check Pointer Bounds Before Dereference**:
   - Reordered loop condition to `p < block_end && *p != 0` so `p` is verified strictly within bounds before dereferencing `*p`.
2. **Validate Record Length & Sector Boundaries**:
   - Added check `if (*p < 34 || *p > (size_t)(block_end - p)) break;` to ensure directory records are at least 34 bytes and never cross sector boundaries. Corrupted or truncated boundary records break out of the block scan cleanly without out-of-bounds reads or infinite loops.
3. **Validate Record & Name Length in `parse_file_info`**:
   - Added validation ensuring that `isodirrec[DR_length_offset] >= 34` and `DR_name_offset + name_len <= isodirrec[DR_length_offset]`.
4. **Guard `parse_file_info` Return**:
   - Checked that `child != NULL` before calling `add_entry(iso9660, child)`.

## Reference
Upstream libarchive commit `bd0cae0be7461b045c2691acf3c73e6e4090199a`.