### PR TITLE
cpio: fix 32-bit binary field decoding and validate entry size

### DIFF
--- a/libarchive/archive_read_support_format_cpio.c
+++ b/libarchive/archive_read_support_format_cpio.c
@@ -41,6 +41,7 @@ __FBSDID("$FreeBSD: src/lib/libarchive/archive_read_support_format_cpio.c,v 1.27
 #include "archive_entry.h"
 #include "archive_private.h"
 #include "archive_read_private.h"
+#include "archive_endian.h"
 
 struct cpio_bin_header {
 	unsigned char	c_magic[2];
@@ -117,7 +118,7 @@ static int	archive_read_format_cpio_read_data(struct archive_read *,
 		    const void **, size_t *, off_t *);
 static int	archive_read_format_cpio_read_header(struct archive_read *,
 		    struct archive_entry *);
-static int	be4(const unsigned char *);
+static int64_t	be4(const unsigned char *);
 static int	find_odc_header(struct archive_read *);
 static int	find_newc_header(struct archive_read *);
 static int	header_bin_be(struct archive_read *, struct cpio *,
@@ -130,7 +131,7 @@ static int	header_odc(struct archive_read *, struct cpio *,
 		    struct archive_entry *, size_t *, size_t *);
 static int	is_octal(const char *, size_t);
 static int	is_hex(const char *, size_t);
-static int	le4(const unsigned char *);
+static int64_t	le4(const unsigned char *);
 static void	record_hardlink(struct cpio *cpio, struct archive_entry *entry);
 
 int
@@ -607,6 +608,11 @@ header_bin_le(struct archive_read *a, struct cpio *cpio,
 	*name_pad = *namelength & 1; /* Pad to even. */
 
 	cpio->entry_bytes_remaining = le4(header->c_filesize);
+	if (cpio->entry_bytes_remaining < 0) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+		    "Invalid cpio entry size");
+		return (ARCHIVE_FATAL);
+	}
 	archive_entry_set_size(entry, cpio->entry_bytes_remaining);
 	cpio->entry_padding = cpio->entry_bytes_remaining & 1; /* Pad to even. */
 	return (ARCHIVE_OK);
@@ -642,6 +648,11 @@ header_bin_be(struct archive_read *a, struct cpio *cpio,
 	*name_pad = *namelength & 1; /* Pad to even. */
 
 	cpio->entry_bytes_remaining = be4(header->c_filesize);
+	if (cpio->entry_bytes_remaining < 0) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_FILE_FORMAT,
+		    "Invalid cpio entry size");
+		return (ARCHIVE_FATAL);
+	}
 	archive_entry_set_size(entry, cpio->entry_bytes_remaining);
 	cpio->entry_padding = cpio->entry_bytes_remaining & 1; /* Pad to even. */
 	return (ARCHIVE_OK);
@@ -668,17 +679,16 @@ archive_read_format_cpio_cleanup(struct archive_read *a)
 	return (ARCHIVE_OK);
 }
 
-static int
+static int64_t
 le4(const unsigned char *p)
 {
-	return ((p[0]<<16) + (p[1]<<24) + (p[2]<<0) + (p[3]<<8));
+	return ((int64_t)archive_le16dec(p) << 16) | archive_le16dec(p + 2);
 }
 
-
-static int
+static int64_t
 be4(const unsigned char *p)
 {
-	return (p[0] + (p[1]<<8) + (p[2]<<16) + (p[3]<<24));
+	return ((int64_t)archive_be16dec(p) << 16) | archive_be16dec(p + 2);
 }
 
 /*


### PR DESCRIPTION
Fixes #900
Fixes #899

## Problem

In `libarchive/archive_read_support_format_cpio.c`, decoding 32-bit fields (`c_mtime` and `c_filesize`) in binary CPIO archives had two critical defects:

1. **Big-Endian Decoding Byte-Swap (#899)**:
   The `be4()` helper decoded 32-bit fields using little-endian byte arithmetic:
   ```c
   static int
   be4(const unsigned char *p)
   {
       return (p[0] + (p[1]<<8) + (p[2]<<16) + (p[3]<<24));
   }
   ```
   For big-endian binary CPIO archives, this reversed the byte order of `c_filesize`. A valid 255-byte file (`0x000000ff`) was misdecoded as `0xff000000` (4,278,190,080 bytes), causing Tarsnap to spend unbounded CPU time processing the declared virtual size during archive creation (`-c --dry-run`).

2. **Little-Endian Signed Overflow (#900)**:
   The `le4()` helper returned signed 32-bit `int` with signed shifts:
   ```c
   static int
   le4(const unsigned char *p)
   {
       return ((p[0]<<16) + (p[1]<<24) + (p[2]<<0) + (p[3]<<8));
   }
   ```
   When `c_filesize` represented `0x80000000` (2 GiB), `(p[1] << 24)` overflowed signed `int`, resulting in `-2147483648`. Assigning this negative value to `cpio->entry_bytes_remaining` and the entry size caused Tarsnap to enter an unbounded CPU hashing loop in `chunkify_write()`.

3. **Unvalidated Negative Entry Size**:
   Neither `header_bin_le()` nor `header_bin_be()` checked if `cpio->entry_bytes_remaining` was negative before passing it to `archive_entry_set_size()`.

## Solution

1. **Checked Endian Decoders**:
   Included `archive_endian.h` and refactored both `le4()` and `be4()` to return `int64_t` using the standard checked helpers `archive_le16dec()` and `archive_be16dec()`:
   ```c
   static int64_t
   le4(const unsigned char *p)
   {
       return ((int64_t)archive_le16dec(p) << 16) | archive_le16dec(p + 2);
   }

   static int64_t
   be4(const unsigned char *p)
   {
       return ((int64_t)archive_be16dec(p) << 16) | archive_be16dec(p + 2);
   }
   ```
   - `be4()` now correctly decodes big-endian fields in big-endian binary CPIO archives, properly recovering actual file sizes (e.g. 255 bytes).
   - `le4()` decodes 32-bit little-endian values into `int64_t` without signed 32-bit shift overflow, properly representing 2 GiB as `+2147483648`.

2. **Size Validation in Header Parsers**:
   Added validation in both `header_bin_le()` and `header_bin_be()` ensuring `cpio->entry_bytes_remaining >= 0`. Any negative size is rejected with `ARCHIVE_FATAL` and message `"Invalid cpio entry size"`.