### PR TITLE
zip: check __archive_read_ahead return pointer in SFX bidder (#919)

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -212,6 +212,8 @@ archive_read_format_zip_bid(struct archive_read *a)
 			/* Get 4k of data beyond where we stopped. */
 			buff = __archive_read_ahead(a, offset + 4096,
 			    &bytes_avail);
+			if (buff == NULL)
+				break;
 			if (bytes_avail < offset + 1)
 				break;
 			p = (const char *)buff + offset;


### PR DESCRIPTION
### Summary
Fixes #919.

In `archive_read_format_zip_bid()`, when scanning for self-extracting ZIP headers, `__archive_read_ahead(a, offset + 4096, &bytes_avail)` is invoked to request a larger read-ahead window. When the request cannot be satisfied, it returns `buff = NULL`. However, the existing check only evaluated `if (bytes_avail < offset + 1)`, which can remain false when `bytes_avail` is unupdated or reflects previous available data, causing `p = (const char *)buff + offset` to construct an invalid offset pointer and dereference it at line 219, crashing Tarsnap with SIGSEGV (exit 139).

### Fix
Explicitly verify that `buff != NULL` before proceeding with pointer arithmetic:
```c
buff = __archive_read_ahead(a, offset + 4096, &bytes_avail);
if (buff == NULL)
    break;
if (bytes_avail < offset + 1)
    break;
```
This matches upstream libarchive's fix (issue 76, commit 1fb2ae5cc0d9d5d12bd8bd7ea4a88f138072d6c4) and ensures malformed or boundary inputs are rejected cleanly without a crash.

Eligible for Colin Percival's bug bounty program for issue #919.