### PR TITLE
zip: compare full 64-bit uncompressed size without truncation (#910)

### DIFF
--- a/libarchive/archive_read_support_format_zip.c
+++ b/libarchive/archive_read_support_format_zip.c
@@ -566,9 +566,8 @@ archive_read_format_zip_read_data(struct archive_read *a,
 			    "ZIP compressed data is wrong size");
 			return (ARCHIVE_WARN);
 		}
-		/* Size field only stores the lower 32 bits of the actual size. */
-		if ((zip->uncompressed_size & UINT32_MAX)
-		    != (zip->entry_uncompressed_bytes_read & UINT32_MAX)) {
+		/* Check uncompressed size matches bytes actually read. */
+		if (zip->uncompressed_size != zip->entry_uncompressed_bytes_read) {
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 			    "ZIP uncompressed data is wrong size");
 			return (ARCHIVE_WARN);


### PR DESCRIPTION
### Summary
Fixes #910.

In `archive_read_support_format_zip.c:archive_read_format_zip_read_data()`, the reader checked whether the uncompressed size matched the total uncompressed bytes read:
```c
if ((zip->uncompressed_size & UINT32_MAX)
    != (zip->entry_uncompressed_bytes_read & UINT32_MAX))
```

When a ZIP64 entry declares a 64-bit size (e.g. `2^32 + 5`), masking with `UINT32_MAX` only checks the lower 32 bits. If the physical input contains only 5 bytes, `(2^32 + 5) & UINT32_MAX == 5`, satisfying the check. The PAX writer then synthesizes and hashes null bytes for the remainder (approximately 4 GiB), causing an unbounded CPU-bound loop on small inputs.

### Fix
Remove the `UINT32_MAX` truncation mask and directly compare the full 64-bit `zip->uncompressed_size` against `zip->entry_uncompressed_bytes_read`:
```c
if (zip->uncompressed_size != zip->entry_uncompressed_bytes_read) {
    archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
        "ZIP uncompressed data is wrong size");
    return (ARCHIVE_WARN);
}
```
This matches the existing 64-bit comparison used for `compressed_size` and correctly identifies size mismatches on ZIP64 entries.

Eligible for Colin Percival's bug bounty program for issue #910.