### PR TITLE
ar: reject filename table larger than 1GB and BSD name larger than 1MB (#918)

### DIFF
--- a/libarchive/archive_read_support_format_ar.c
+++ b/libarchive/archive_read_support_format_ar.c
@@ -278,7 +278,7 @@ archive_read_format_ar_read_header(struct archive_read *a,
 			return (ARCHIVE_FATAL);
 		}
 		entry_size = (size_t)number;
-		if (entry_size == 0) {
+		if (entry_size == 0 || entry_size > 1024 * 1024 * 1024) {
 			archive_set_error(&a->archive, EINVAL,
 			    "Invalid string table");
 			return (ARCHIVE_WARN);
@@ -353,7 +353,8 @@ archive_read_format_ar_read_header(struct archive_read *a,
 		 * overflowing a size_t and against the filename size
 		 * being larger than the entire entry. */
 		if (number > (uint64_t)(bsd_name_length + 1)
-		    || (off_t)bsd_name_length > ar->entry_bytes_remaining) {
+		    || (off_t)bsd_name_length > ar->entry_bytes_remaining
+		    || bsd_name_length > 1024 * 1024) {
 			archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
 			    "Bad input file size");
 			return (ARCHIVE_FATAL);


### PR DESCRIPTION
### Summary
Fixes #918.

In `archive_read_support_format_ar.c:archive_read_format_ar_read_header()`, the size of the GNU `//` filename-table member was converted to `size_t` and passed directly to `malloc(entry_size)` and `__archive_read_ahead(a, entry_size, NULL)` without an upper bound. An attacker with a tiny (e.g. 68-byte) archive could declare a multi-gigabyte table size, triggering an immediate unbounded allocation and read-ahead attempt before detecting that the archive is truncated. Similarly, BSD `#1/` long names were not bounded by an absolute upper limit.

### Fix
Align with upstream libarchive's limit (commit `caf9b87de21222aa32c3a9b5c620286b2717e71c`):
1. Cap the GNU AR filename table size to at most 1 GiB (`1024 * 1024 * 1024` bytes).
2. Cap BSD AR filename length to at most 1 MiB (`1024 * 1024` bytes).

Oversized declarations are rejected with an appropriate format error prior to allocation or read-ahead.

Eligible for Colin Percival's bug bounty program for issue #918.