### PR TITLE
tar: reject entry sizes >= 2^60 to prevent unbounded hash spin (#913)

### DIFF
--- a/libarchive/archive_read_support_format_tar.c
+++ b/libarchive/archive_read_support_format_tar.c
@@ -419,6 +419,13 @@ archive_read_format_tar_read_header(struct archive_read *a,
 
 	r = tar_read_header(a, tar, entry);
 
+	if (tar->entry_bytes_remaining < 0
+	    || tar->entry_bytes_remaining >= (1LL << 60)) {
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "Tar entry size out of range");
+		return (ARCHIVE_FATAL);
+	}
+
 	/*
 	 * "non-sparse" files are really just sparse files with
 	 * a single block.
@@ -939,6 +946,15 @@ header_common(struct archive_read *a, struct tar *tar,
 	archive_entry_set_uid(entry, tar_atol(header->uid, sizeof(header->uid)));
 	archive_entry_set_gid(entry, tar_atol(header->gid, sizeof(header->gid)));
 	tar->entry_bytes_remaining = tar_atol(header->size, sizeof(header->size));
+	if (tar->entry_bytes_remaining < 0
+	    || tar->entry_bytes_remaining >= (1LL << 60)) {
+		tar->entry_bytes_remaining = 0;
+		tar->realsize = 0;
+		archive_entry_set_size(entry, 0);
+		archive_set_error(&a->archive, ARCHIVE_ERRNO_MISC,
+		    "Tar entry size out of range");
+		return (ARCHIVE_FATAL);
+	}
 	tar->realsize = tar->entry_bytes_remaining;
 	archive_entry_set_size(entry, tar->entry_bytes_remaining);
 	archive_entry_set_mtime(entry, tar_atol(header->mtime, sizeof(header->mtime)), 0);


### PR DESCRIPTION
### Summary
Fixes #913.

In `archive_read_support_format_tar.c:header_common()`, `tar->entry_bytes_remaining` was assigned directly from `tar_atol(header->size, ...)` without an upper bound check. On malformed archives containing GNU base-256 size fields declaring `2^60` bytes (1 EiB), `archive_read_format_tar_read_header()` created a single sparse block covering the declared value. Even under `--dry-run`, the PAX writer and chunkifier hashed synthetic zero-filled blocks until exhausting the declared 1 EiB size, causing a deterministic local denial of service.

### Fix
Align with upstream libarchive's limit (commit `808059a01f28977bdb366723dd8d4ab79fb6b0a0`):
Reject TAR entry sizes that are negative or greater than or equal to `2^60` (`1LL << 60`) bytes in `header_common()` and `archive_read_format_tar_read_header()`, terminating with `ARCHIVE_FATAL` and `"Tar entry size out of range"`.

Eligible for Colin Percival's bug bounty program for issue #913.